### PR TITLE
Reworked missed work avoidance mechanism

### DIFF
--- a/src/tbb/arena_slot.cpp
+++ b/src/tbb/arena_slot.cpp
@@ -60,6 +60,7 @@ d1::task* arena_slot::get_task_impl(size_t T, execution_data_ext& ed, bool& task
 
 d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation) {
     __TBB_ASSERT(is_task_pool_published(), nullptr);
+    __TBB_ASSERT(shadow_tail.load(std::memory_order_relaxed) == tail.load(std::memory_order_relaxed), nullptr);
     // The current task position in the task pool.
     std::size_t T0 = tail.load(std::memory_order_relaxed);
     // The bounds of available tasks in the task pool. H0 is only used when the head bound is reached.
@@ -122,11 +123,10 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation)
             if ( H0 < T0 ) {
                 // Restore the task pool if there are some tasks.
                 head.store(H0, std::memory_order_relaxed);
+                shadow_head.store(H0, std::memory_order_relaxed);
                 tail.store(T0, std::memory_order_relaxed);
                 // The release fence is used in publish_task_pool.
                 publish_task_pool();
-                // Synchronize with snapshot as we published some tasks.
-                ed.task_disp->m_thread_data->my_arena->advertise_new_work<arena::wakeup>();
             }
         } else {
             // A task has been obtained. We need to make a hole in position T.
@@ -134,12 +134,10 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation)
             __TBB_ASSERT( result, nullptr );
             task_pool_ptr[T] = nullptr;
             tail.store(T0, std::memory_order_release);
-            // Synchronize with snapshot as we published some tasks.
-            // TODO: consider some approach not to call wakeup for each time. E.g. check if the tail reached the head.
-            ed.task_disp->m_thread_data->my_arena->advertise_new_work<arena::wakeup>();
         }
     }
 
+    shadow_tail.store(tail.load(std::memory_order_relaxed), std::memory_order_relaxed);
     __TBB_ASSERT( (std::intptr_t)tail.load(std::memory_order_relaxed) >= 0, nullptr );
     __TBB_ASSERT( result || tasks_omitted || is_quiescent_local_task_pool_reset(), nullptr );
     return result;
@@ -147,6 +145,7 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation)
 
 d1::task* arena_slot::steal_task(arena& a, isolation_type isolation, std::size_t slot_index) {
     d1::task** victim_pool = lock_task_pool();
+    __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == head.load(std::memory_order_relaxed), nullptr);
     if (!victim_pool) {
         return nullptr;
     }
@@ -197,19 +196,16 @@ d1::task* arena_slot::steal_task(arena& a, isolation_type isolation, std::size_t
         // Some proxies in the task pool have been omitted. Set the stolen task to nullptr.
         victim_pool[H-1] = nullptr;
         // The release store synchronizes the victim_pool update(the store of nullptr).
-        head.store( /*dead: H = */ H0, std::memory_order_release );
+        head.store(/*dead: H = */ H0, std::memory_order_release);
     }
 unlock:
+    shadow_head.store(head.load(std::memory_order_relaxed), std::memory_order_relaxed);
     unlock_task_pool(victim_pool);
 
 #if __TBB_PREFETCHING
     __TBB_cl_evict(&victim_slot.head);
     __TBB_cl_evict(&victim_slot.tail);
 #endif
-    if (tasks_omitted) {
-        // Synchronize with snapshot as the head and tail can be bumped which can falsely trigger EMPTY state
-        a.advertise_new_work<arena::wakeup>();
-    }
     return result;
 }
 

--- a/src/tbb/arena_slot.cpp
+++ b/src/tbb/arena_slot.cpp
@@ -145,12 +145,12 @@ d1::task* arena_slot::get_task(execution_data_ext& ed, isolation_type isolation)
 
 d1::task* arena_slot::steal_task(arena& a, isolation_type isolation, std::size_t slot_index) {
     d1::task** victim_pool = lock_task_pool();
-    __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == head.load(std::memory_order_relaxed), nullptr);
     if (!victim_pool) {
         return nullptr;
     }
     d1::task* result = nullptr;
     std::size_t H = head.load(std::memory_order_relaxed); // mirror
+    __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == H, nullptr);
     std::size_t H0 = H;
     bool tasks_omitted = false;
     do {

--- a/src/tbb/arena_slot.h
+++ b/src/tbb/arena_slot.h
@@ -58,6 +58,7 @@ struct alignas(max_nfs_size) arena_slot_shared_state {
     //! Index of the first ready task in the deque.
     /** Modified by thieves, and by the owner during compaction/reallocation **/
     std::atomic<std::size_t> head;
+    std::atomic<std::size_t> shadow_head;
 };
 
 struct alignas(max_nfs_size) arena_slot_private_state {
@@ -76,6 +77,7 @@ struct alignas(max_nfs_size) arena_slot_private_state {
     //! Index of the element following the last ready task in the deque.
     /** Modified by the owner thread. **/
     std::atomic<std::size_t> tail;
+    std::atomic<std::size_t> shadow_tail;
 
     //! Capacity of the primary task pool (number of elements - pointers to task).
     std::size_t my_task_pool_size;
@@ -171,7 +173,7 @@ public:
 
     bool is_empty() const {
         return task_pool.load(std::memory_order_relaxed) == EmptyTaskPool ||
-               head.load(std::memory_order_relaxed) >= tail.load(std::memory_order_relaxed);
+               shadow_head.load(std::memory_order_relaxed) == shadow_tail.load(std::memory_order_relaxed);
     }
 
     bool is_occupied() const {
@@ -211,6 +213,7 @@ private:
     /** If necessary relocates existing task pointers or grows the ready task deque.
      *  Returns (possible updated) tail index (not accounting for n). **/
     std::size_t prepare_task_pool(std::size_t num_tasks) {
+        __TBB_ASSERT(shadow_tail.load(std::memory_order_relaxed) == tail.load(std::memory_order_relaxed), nullptr);
         std::size_t T = tail.load(std::memory_order_relaxed); // mirror
         if ( T + num_tasks <= my_task_pool_size ) {
             return T;
@@ -225,6 +228,8 @@ private:
             return 0;
         }
         acquire_task_pool();
+        __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == head.load(std::memory_order_relaxed),
+            "No thief is expected so head should be equal to its shadow");
         std::size_t H =  head.load(std::memory_order_relaxed); // mirror
         d1::task** new_task_pool = task_pool_ptr;
         __TBB_ASSERT( my_task_pool_size >= min_task_pool_size, nullptr);
@@ -267,14 +272,17 @@ private:
         // Release fence is necessary to make sure that previously stored task pointers
         // are visible to thieves.
         tail.store(new_tail, std::memory_order_release);
+        shadow_tail.store(new_tail, std::memory_order_relaxed);
     }
 
     //! Used by workers to enter the task pool
     /** Does not lock the task pool in case if arena slot has been successfully grabbed. **/
     void publish_task_pool() {
-        __TBB_ASSERT ( task_pool == EmptyTaskPool, "someone else grabbed my arena slot?" );
-        __TBB_ASSERT ( head.load(std::memory_order_relaxed) < tail.load(std::memory_order_relaxed),
-                "entering arena without tasks to share" );
+        __TBB_ASSERT(task_pool == EmptyTaskPool, "someone else grabbed my arena slot?");
+        __TBB_ASSERT(shadow_tail.load(std::memory_order_relaxed) == tail.load(std::memory_order_relaxed), nullptr);
+        __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == head.load(std::memory_order_relaxed), nullptr);
+        __TBB_ASSERT(head.load(std::memory_order_relaxed) < tail.load(std::memory_order_relaxed),
+                "entering arena without tasks to share");
         // Release signal on behalf of previously spawned tasks (when this thread was not in arena yet)
         task_pool.store(task_pool_ptr, std::memory_order_release );
     }
@@ -364,6 +372,8 @@ private:
 
     bool is_quiescent_local_task_pool_empty() const {
         __TBB_ASSERT(is_local_task_pool_quiescent(), "Task pool is not quiescent");
+        __TBB_ASSERT(shadow_tail.load(std::memory_order_relaxed) == tail.load(std::memory_order_relaxed), nullptr);
+        __TBB_ASSERT(shadow_head.load(std::memory_order_relaxed) == head.load(std::memory_order_relaxed), nullptr);
         return head.load(std::memory_order_relaxed) == tail.load(std::memory_order_relaxed);
     }
 
@@ -392,6 +402,8 @@ private:
         __TBB_ASSERT(task_pool.load(std::memory_order_relaxed) == LockedTaskPool, "Task pool must be locked when resetting task pool");
         tail.store(0, std::memory_order_relaxed);
         head.store(0, std::memory_order_relaxed);
+        shadow_tail.store(0, std::memory_order_relaxed);
+        shadow_head.store(0, std::memory_order_relaxed);
         leave_task_pool();
     }
 
@@ -400,9 +412,11 @@ private:
     void commit_relocated_tasks(std::size_t new_tail) {
         __TBB_ASSERT(is_local_task_pool_quiescent(), "Task pool must be locked when calling commit_relocated_tasks()");
         head.store(0, std::memory_order_relaxed);
+        shadow_head.store(0, std::memory_order_relaxed);
         // Tail is updated last to minimize probability of a thread making arena
         // snapshot being misguided into thinking that this task pool is empty.
         tail.store(new_tail, std::memory_order_release);
+        shadow_tail.store(new_tail, std::memory_order_relaxed);
         release_task_pool();
     }
 };


### PR DESCRIPTION
When threads execute `get_task` or `steal_task` they can omit unsuitable tasks (different isolation or affinity). The omitted tasks are virtually extracted from task pool, that makes them temporary invisible for other threads. It might lead to situation when another thread marks the arena `EMPTY` (as a result of `is_out_of_work()`), while these tasks are still in the arena. If tasks were omitted we need to notify the arena like new work was added (calling `advertise_new_work()`).

The proposed idea is that omit tasks in such way that other threads can not observe it. It will prevent unnecessary arena state transition and premature threads leaving. 

Therefore, the patch introduce shadow tail and head which move after real task extracted(do not participate in tasks omitting mechanism). 

Signed-off-by: pavelkumbrasev <pavel.kumbrasev@intel.com>