### PR TITLE
Enable CTAD for blocked_rangeNd since C++17

### DIFF
--- a/include/oneapi/tbb/blocked_nd_range.h
+++ b/include/oneapi/tbb/blocked_nd_range.h
@@ -47,11 +47,9 @@ namespace d1 {
 */
 
 template<typename Value, unsigned int N, typename = detail::make_index_sequence<N>>
-    __TBB_requires(blocked_range_value<Value>)
 class blocked_nd_range_impl;
 
 template<typename Value, unsigned int N, std::size_t... Is>
-    __TBB_requires(blocked_range_value<Value>)
 class blocked_nd_range_impl<Value, N, detail::index_sequence<Is...>> {
 public:
     //! Type of a value.
@@ -142,9 +140,9 @@ private:
 };
 
 template<typename Value, unsigned int N>
+         __TBB_requires(blocked_range_value<Value>)
 class blocked_nd_range : public blocked_nd_range_impl<Value, N> {
     using base = blocked_nd_range_impl<Value, N>;
-
     // Making constructors of base class visible
     using base::base;
 };

--- a/include/oneapi/tbb/blocked_nd_range.h
+++ b/include/oneapi/tbb/blocked_nd_range.h
@@ -142,7 +142,12 @@ private:
 };
 
 template<typename Value, unsigned int N>
-using blocked_nd_range = blocked_nd_range_impl<Value, N>;
+class blocked_nd_range : public blocked_nd_range_impl<Value, N> {
+    using base = blocked_nd_range_impl<Value, N>;
+
+    // Making constructors of base class visible
+    using base::base;
+};
 
 } // namespace d1
 } // namespace detail

--- a/include/oneapi/tbb/blocked_nd_range.h
+++ b/include/oneapi/tbb/blocked_nd_range.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2017-2024 Intel Corporation
+    Copyright (c) 2017-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/blocked_range.h
+++ b/include/oneapi/tbb/blocked_range.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/blocked_range.h
+++ b/include/oneapi/tbb/blocked_range.h
@@ -151,12 +151,7 @@ private:
     friend class blocked_range3d;
 
     template<typename DimValue, unsigned int N, typename>
-<<<<<<< HEAD
-        __TBB_requires(blocked_range_value<DimValue>)
     friend class blocked_nd_range_impl;
-=======
-    friend class blocked_rangeNd_impl;
->>>>>>> 3fe65dcb (Fix constraits test failure)
 };
 
 } // namespace d1

--- a/include/oneapi/tbb/blocked_range.h
+++ b/include/oneapi/tbb/blocked_range.h
@@ -151,8 +151,12 @@ private:
     friend class blocked_range3d;
 
     template<typename DimValue, unsigned int N, typename>
+<<<<<<< HEAD
         __TBB_requires(blocked_range_value<DimValue>)
     friend class blocked_nd_range_impl;
+=======
+    friend class blocked_rangeNd_impl;
+>>>>>>> 3fe65dcb (Fix constraits test failure)
 };
 
 } // namespace d1


### PR DESCRIPTION
### Description 
Enable CTAD for blocked_rangeNd since C++17 by making the implementation through the inheritance rather than through alias template.

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [X] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [x] Yes
- [x] No
- [ ] Unknown

Technically, the change breaks backward compatibility but this is a preview functionality, where breaking change is acceptable

### Notify the following users
@pavelkumbrasev, @vossmjp, @akukanov, @isaevil, @aleksei-fedotov, @kboyarinov 

### Other information
Of course, this PR should take into account the changes made in #1449. I cloned 1449 and checked my modifications there. Didn't find any broken tests (I might miss something, though).

Please provide feedback on my PR if anybody sees any issues with proposed changes
