### PR TITLE
Fix cmake integrate

### DIFF
--- a/doc/GSG/integrate.rst
+++ b/doc/GSG/integrate.rst
@@ -26,10 +26,10 @@ Integrating oneTBB into your project using CMake*:
 
 To add oneTBB to another project using CMake*, add the following commands to your ``CMakeLists.txt`` file:
 
-.. code-block::
+.. code-block:: cmake
 
-       `find_package(TBB REQUIRED)`
-       `target_link_libraries(my_executable TBB::tbb)`
+       find_package(TBB REQUIRED)
+       target_link_libraries(my_executable TBB::tbb)
 
 After that, configure your project with CMake* as usual.
 


### PR DESCRIPTION
### Description 
Remove unneeded backquote, and add code block language

Before 
![image](https://github.com/user-attachments/assets/306046c0-e53c-49b1-b3f9-9f1eeed05932)

After 
![image](https://github.com/user-attachments/assets/8bda43e3-5ff0-4bff-9469-55c182f4c3a1)


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
