### PR TITLE
Fix broken links after migration to uxlfoundation org.

### DIFF
--- a/Bazel.md
+++ b/Bazel.md
@@ -40,7 +40,7 @@ load("@platforms//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "oneTBB",
     branch = "master",
-    remote = "https://github.com/oneapi-src/oneTBB/",
+    remote = "https://github.com/uxlfoundation/oneTBB/",
 )
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,17 +19,17 @@ As an open source project, we welcome community contributions to oneAPI Threadin
 
 ## Licensing 
 
-Licensing is very important to open source projects. It helps ensure the software continues to be available under the terms that the author desired. The oneTBB project uses the [Apache 2.0 License](https://github.com/oneapi-src/oneTBB/blob/master/LICENSE.txt), a permissive open source license that allows you to freely use, modify, and distribute your own products that include Apache 2.0 licensed software. By contributing to the oneTBB project, you agree to the license and copyright terms therein and release your own contributions under these terms. 
+Licensing is very important to open source projects. It helps ensure the software continues to be available under the terms that the author desired. The oneTBB project uses the [Apache 2.0 License](https://github.com/uxlfoundation/oneTBB/blob/master/LICENSE.txt), a permissive open source license that allows you to freely use, modify, and distribute your own products that include Apache 2.0 licensed software. By contributing to the oneTBB project, you agree to the license and copyright terms therein and release your own contributions under these terms. 
 
-Some imported or reused components within oneTBB use other licenses, as described in [third-party-programs.txt](https://github.com/oneapi-src/oneTBB/blob/master/third-party-programs.txt). By carefully reviewing potential contributions, we can ensure that the community can develop products with oneTBB without concerns over patent or copyright issues. 
+Some imported or reused components within oneTBB use other licenses, as described in [third-party-programs.txt](https://github.com/uxlfoundation/oneTBB/blob/master/third-party-programs.txt). By carefully reviewing potential contributions, we can ensure that the community can develop products with oneTBB without concerns over patent or copyright issues. 
 
 ## Prerequisites 
 
-As a contributor, you’ll want to be familiar with the oneTBB project and the repository layout. You should also know how to use it as explained in the [oneTBB documentation](https://oneapi-src.github.io/oneTBB/) and how to set up your build development environment to configure, build, and test oneTBB as explained in the [oneTBB Build System Description](cmake/README.md). 
+As a contributor, you'll want to be familiar with the oneTBB project and the repository layout. You should also know how to use it as explained in the [oneTBB documentation](https://uxlfoundation.github.io/oneTBB/) and how to set up your build development environment to configure, build, and test oneTBB as explained in the [oneTBB Build System Description](cmake/README.md). 
 
 ## Pull Requests 
 
-You can find all [open oneTBB pull requests](https://github.com/oneapi-src/oneTBB/pulls) on GitHub. 
+You can find all [open oneTBB pull requests](https://github.com/uxlfoundation/oneTBB/pulls) on GitHub. 
  
 ### Before contributing changes directly to the oneTBB repository
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,7 @@ You can use the ``install`` components for partial installation.
 The following install components are supported:
 - `runtime` - oneTBB runtime package (core shared libraries and `.dll` files on Windows* OS).
 - `devel` - oneTBB development package (header files, CMake integration files, library symbolic links, and `.lib` files on Windows* OS).
-- `tbb4py` - [oneTBB Module for Python](https://github.com/oneapi-src/oneTBB/blob/master/python/README.md).
+- `tbb4py` - [oneTBB Module for Python](https://github.com/uxlfoundation/oneTBB/blob/master/python/README.md).
 
 If you want to install specific components after configuration and build, run:
 
@@ -99,7 +99,7 @@ The following example demonstrates how to install oneTBB for single-configuratio
 # Do our experiments in /tmp
 cd /tmp
 # Clone oneTBB repository
-git clone https://github.com/oneapi-src/oneTBB.git
+git clone https://github.com/uxlfoundation/oneTBB.git
 cd oneTBB
 # Create binary directory for out-of-source build
 mkdir build && cd build
@@ -121,7 +121,7 @@ Choose the configuration during the build and install steps:
 REM Do our experiments in %TMP%
 cd %TMP%
 REM Clone oneTBB repository
-git clone https://github.com/oneapi-src/oneTBB.git
+git clone https://github.com/uxlfoundation/oneTBB.git
 cd oneTBB
 REM Create binary directory for out-of-source build
 mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # oneAPI Threading Building Blocks (oneTBB) <img align="right" width="200" height="100" src="https://raw.githubusercontent.com/uxlfoundation/artwork/e98f1a7a3d305c582d02c5f532e41487b710d470/foundation/uxl-foundation-logo-horizontal-color.svg">
-[![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE.txt) [![oneTBB CI](https://github.com/oneapi-src/oneTBB/actions/workflows/ci.yml/badge.svg)](https://github.com/oneapi-src/oneTBB/actions/workflows/ci.yml?query=branch%3Amaster)
-[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/blue?icon=github)](https://github.com/oneapi-src/oneTBB/discussions)
+[![Apache License Version 2.0](https://img.shields.io/badge/license-Apache_2.0-green.svg)](LICENSE.txt) [![oneTBB CI](https://github.com/uxlfoundation/oneTBB/actions/workflows/ci.yml/badge.svg)](https://github.com/uxlfoundation/oneTBB/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Join the community on GitHub Discussions](https://badgen.net/badge/join%20the%20discussion/on%20github/blue?icon=github)](https://github.com/uxlfoundation/oneTBB/discussions)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9125/badge)](https://www.bestpractices.dev/projects/9125)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/oneapi-src/oneTBB/badge)](https://securityscorecards.dev/viewer/?uri=github.com/oneapi-src/oneTBB)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/uxlfoundation/oneTBB/badge)](https://securityscorecards.dev/viewer/?uri=github.com/uxlfoundation/oneTBB)
 
 oneTBB is a flexible C++ library that simplifies the work of adding parallelism
 to complex applications, even if you are not a threading expert.  
@@ -31,12 +31,12 @@ See [Release Notes](RELEASE_NOTES.md) and [System Requirements](SYSTEM_REQUIREME
 
 ## Documentation
 * [oneTBB Specification](https://spec.oneapi.com/versions/latest/elements/oneTBB/source/nested-index.html)
-* [oneTBB Developer Guide and Reference](https://oneapi-src.github.io/oneTBB)
-* [Migrating from TBB to oneTBB](https://oneapi-src.github.io/oneTBB/main/tbb_userguide/Migration_Guide.html)
+* [oneTBB Developer Guide and Reference](https://uxlfoundation.github.io/oneTBB)
+* [Migrating from TBB to oneTBB](https://uxlfoundation.github.io/oneTBB/main/tbb_userguide/Migration_Guide.html)
 * [README for the CMake build system](cmake/README.md)
-* [oneTBB Testing Approach](https://oneapi-src.github.io/oneTBB/main/intro/testing_approach.html)
+* [oneTBB Testing Approach](https://uxlfoundation.github.io/oneTBB/main/intro/testing_approach.html)
 * [Basic support for the Bazel build system](Bazel.md)
-* [oneTBB Discussions](https://github.com/oneapi-src/oneTBB/discussions)
+* [oneTBB Discussions](https://github.com/uxlfoundation/oneTBB/discussions)
 * [WASM Support](WASM_Support.md)
 
 ## Installation 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,19 +33,19 @@ This document contains changes of oneTBB compared to the last release.
 - On Windows OS on ARM64*, when compiling an application using oneTBB with the Microsoft* Compiler, the compiler issues a warning C4324 that a structure was padded due to the alignment specifier. Consider suppressing the warning by specifying /wd4324 to the compiler command line.
 - C++ exception handling mechanism on Windows* OS on ARM64* might corrupt memory if an exception is thrown from any oneTBB parallel algorithm (see Windows* OS on ARM64* compiler issue: https://developercommunity.visualstudio.com/t/ARM64-incorrect-stack-unwinding-for-alig/1544293.
 - When CPU resource coordination is enabled, tasks from a lower-priority ``task_arena`` might be executed before tasks from a higher-priority ``task_arena``.
-- Using oneTBB on WASM*, may cause applications to run in a single thread. See [Limitations of WASM Support](https://github.com/oneapi-src/oneTBB/blob/master/WASM_Support.md#limitations).
+- Using oneTBB on WASM*, may cause applications to run in a single thread. See [Limitations of WASM Support](https://github.com/uxlfoundation/oneTBB/blob/master/WASM_Support.md#limitations).
 
-> **_NOTE:_**  To see known limitations that impact all versions of oneTBB, refer to [oneTBB Documentation](https://oneapi-src.github.io/oneTBB/main/intro/limitations.html).
+> **_NOTE:_**  To see known limitations that impact all versions of oneTBB, refer to [oneTBB Documentation](https://uxlfoundation.github.io/oneTBB/main/intro/limitations.html).
 
 
 ## :hammer: Issues Fixed
 - Fixed the missed signal for thread request for enqueue operation.
 - Significantly improved scalability of ``task_group``, ``flow_graph``, and ``parallel_for_each``.
-- Removed usage of ``std::aligned_storage`` deprecated in C++23 (Inspired by Valery Matskevich https://github.com/oneapi-src/oneTBB/pull/1394).
+- Removed usage of ``std::aligned_storage`` deprecated in C++23 (Inspired by Valery Matskevich https://github.com/uxlfoundation/oneTBB/pull/1394).
 - Fixed the issue where ``oneapi::tbb::info`` interfaces might interfere with the process affinity mask on the Windows* OS systems with multiple processor groups.
 
 
 ## :octocat: Open-Source Contributions Integrated
-- Detect the GNU Binutils version to determine WAITPKG support better. Contributed by Martijn Courteaux (https://github.com/oneapi-src/oneTBB/pull/1347).
-- Fixed the build on non-English locales. Contributed by Vladislav Shchapov (https://github.com/oneapi-src/oneTBB/pull/1450). 
-- Improved Bazel support. Contributed by Julian Amann (https://github.com/oneapi-src/oneTBB/pull/1434).
+- Detect the GNU Binutils version to determine WAITPKG support better. Contributed by Martijn Courteaux (https://github.com/uxlfoundation/oneTBB/pull/1347).
+- Fixed the build on non-English locales. Contributed by Vladislav Shchapov (https://github.com/uxlfoundation/oneTBB/pull/1450). 
+- Improved Bazel support. Contributed by Julian Amann (https://github.com/uxlfoundation/oneTBB/pull/1434).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,6 @@ If you have any suggestions on how this Policy could be improved, submit
 an issue or a pull request to this repository. **Do not** report
 potential vulnerabilities or security flaws via a pull request.
 
-[1]: https://github.com/oneapi-src/oneTBB/releases/latest
-[2]: https://github.com/oneapi-src/oneTBB/security/advisories/new
-[3]: https://github.com/oneapi-src/oneTBB/security/advisories
+[1]: https://github.com/uxlfoundation/oneTBB/releases/latest
+[2]: https://github.com/uxlfoundation/oneTBB/security/advisories/new
+[3]: https://github.com/uxlfoundation/oneTBB/security/advisories

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,14 +21,14 @@ Use the following methods if you face any challenges.
 
 ## Issues
 
-If you have a problem, check out the [GitHub Issues](https://github.com/oneapi-src/oneTBB/issues) to see if the issue you want to address is already reported. 
+If you have a problem, check out the [GitHub Issues](https://github.com/uxlfoundation/oneTBB/issues) to see if the issue you want to address is already reported. 
 You may find users that have encountered the same bug or have similar ideas for changes or updates.
 
 You can use issues to report a problem, make a feature request, or add comments on an existing issue.
 
 ## Discussions 
 
-Visit the [GitHub Discussions](https://github.com/oneapi-src/oneTBB/discussions) to engage with the community, ask questions, or help others. 
+Visit the [GitHub Discussions](https://github.com/uxlfoundation/oneTBB/discussions) to engage with the community, ask questions, or help others. 
 
 ## Email
 

--- a/WASM_Support.md
+++ b/WASM_Support.md
@@ -47,7 +47,7 @@ Where:
 * ``-DCMAKE_C_COMPILER=emcc`` - specifies the C compiler as Emscripten* C compiler.
 
 
-> **_NOTE:_** See [CMake documentation](https://github.com/oneapi-src/oneTBB/blob/master/cmake/README.md) to learn about other options. 
+> **_NOTE:_** See [CMake documentation](https://github.com/uxlfoundation/oneTBB/blob/master/cmake/README.md) to learn about other options. 
 
 
 ## Run Test

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -48,7 +48,7 @@ Some useful options:
 
 #### TBBBind Library Configuration
 
-> **_TIP:_** It is recommended to install the HWLOC* library. See [oneTBB documentation](https://oneapi-src.github.io/oneTBB/GSG/next_steps.html#hybrid-cpu-and-numa-support) for details.
+> **_TIP:_** It is recommended to install the HWLOC* library. See [oneTBB documentation](https://uxlfoundation.github.io/oneTBB/GSG/next_steps.html#hybrid-cpu-and-numa-support) for details.
 
 The TBBbind library has three versions: `tbbbind`, `tbbbind_2_0`, and `tbbbind_2_5`. Each of these versions is linked with the corresponding HWLOC* library version: 
 - `tbbbind` links with `HWLOC 1.11.x`
@@ -270,7 +270,7 @@ Variable | Description
 `TBB_VERSION`           | oneTBB version (format: `<major>.<minor>.<patch>.<tweak>`)
 `TBB_IMPORTED_TARGETS`  | All created oneTBB imported targets (not supported for builds from source code)
 
-Starting from [oneTBB 2021.1](https://github.com/oneapi-src/oneTBB/releases/tag/v2021.1), GitHub* release TBBConfig files in the binary packages are located under `<tbb-root>/lib/cmake/TBB`.
+Starting from [oneTBB 2021.1](https://github.com/uxlfoundation/oneTBB/releases/tag/v2021.1), GitHub* release TBBConfig files in the binary packages are located under `<tbb-root>/lib/cmake/TBB`.
 For example, `TBB_DIR` should be set to `<tbb-root>/lib/cmake/TBB`.
 
 TBBConfig files are automatically created during the build from source code and can be installed together with the library.

--- a/doc/GSG/installation.rst
+++ b/doc/GSG/installation.rst
@@ -3,5 +3,5 @@
 Installation
 ============
 
-See the `installation instructions <https://github.com/oneapi-src/oneTBB/blob/master/INSTALL.md>`_ 
+See the `installation instructions <https://github.com/uxlfoundation/oneTBB/blob/master/INSTALL.md>`_ 
 that will help you to install |short_name| successfully.  

--- a/doc/GSG/samples.rst
+++ b/doc/GSG/samples.rst
@@ -10,40 +10,40 @@ The following samples are available:
 
 * **Containers** 
 
-  * `concurrent_hash_map <https://github.com/oneapi-src/oneTBB/tree/master/examples/concurrent_hash_map>`_ 
-  * `concurrent_priority_queue <https://github.com/oneapi-src/oneTBB/tree/master/examples/concurrent_priority_queue>`_ 
+  * `concurrent_hash_map <https://github.com/uxlfoundation/oneTBB/tree/master/examples/concurrent_hash_map>`_ 
+  * `concurrent_priority_queue <https://github.com/uxlfoundation/oneTBB/tree/master/examples/concurrent_priority_queue>`_ 
 
-* `Flow Graph <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph>`_ 
-   * `A solution to the binpacking problem using a queue_node, a buffer_node, and function_node. <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/binpack>`_ 
-   * `Cholesky Factorization algorithm <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/cholesky>`_
-   * `An implementation of dining philosophers in graph using the reserving join_node <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/dining_philosophers>`_
-   * `A parallel implementation of bzip2 block-sorting file compressor <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/fgbzip2>`_
-   * `An example of a collection of digital logic gates that can be easily composed into larger circuits <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/logic_sim>`_
-   * `An example of a Kohonen Self-Organizing Map using cancellation <https://github.com/oneapi-src/oneTBB/tree/master/examples/graph/som>`_
+* `Flow Graph <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph>`_ 
+   * `A solution to the binpacking problem using a queue_node, a buffer_node, and function_node. <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/binpack>`_ 
+   * `Cholesky Factorization algorithm <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/cholesky>`_
+   * `An implementation of dining philosophers in graph using the reserving join_node <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/dining_philosophers>`_
+   * `A parallel implementation of bzip2 block-sorting file compressor <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/fgbzip2>`_
+   * `An example of a collection of digital logic gates that can be easily composed into larger circuits <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/logic_sim>`_
+   * `An example of a Kohonen Self-Organizing Map using cancellation <https://github.com/uxlfoundation/oneTBB/tree/master/examples/graph/som>`_
    * `Split computational kernel for execution between CPU and GPU <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneTBB/tbb-async-sycl>`_
 
 * **Algorithms**
 
-  * `parallel_for <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for>`_
-     * `Game of life overlay <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for/game_of_life>`_
-     * `Polygon overlay <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for/polygon_overlay>`_
-     * `Parallel seismic wave simulation <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for/seismic>`_
-     * `Parallel 2-D raytracer/renderer <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for/tachyon>`_
-     * `Find largest matching substrings <https://github.com/oneapi-src/oneTBB/tree/master/examples/getting_started>`_
+  * `parallel_for <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for>`_
+     * `Game of life overlay <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for/game_of_life>`_
+     * `Polygon overlay <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for/polygon_overlay>`_
+     * `Parallel seismic wave simulation <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for/seismic>`_
+     * `Parallel 2-D raytracer/renderer <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for/tachyon>`_
+     * `Find largest matching substrings <https://github.com/uxlfoundation/oneTBB/tree/master/examples/getting_started>`_
      * `Resumable task: Split computational kernel for execution between CPU and GPU <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneTBB/tbb-resumable-tasks-sycl>`_
-  * `parallel_for_each <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_for_each>`_
-  * `parallel_pipeline <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_pipeline>`_
-  * `parallel_reduce <https://github.com/oneapi-src/oneTBB/tree/master/examples/parallel_reduce>`_
+  * `parallel_for_each <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_for_each>`_
+  * `parallel_pipeline <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_pipeline>`_
+  * `parallel_reduce <https://github.com/uxlfoundation/oneTBB/tree/master/examples/parallel_reduce>`_
 
 * **Task Scheduler**
 
-  * `task_arena <https://github.com/oneapi-src/oneTBB/tree/master/examples/task_arena>`_
-  * `task_group <https://github.com/oneapi-src/oneTBB/tree/master/examples/task_group>`_
+  * `task_arena <https://github.com/uxlfoundation/oneTBB/tree/master/examples/task_arena>`_
+  * `task_group <https://github.com/uxlfoundation/oneTBB/tree/master/examples/task_group>`_
   * `Execute similar computational kernels, with one task executing the SYCL* code and the other task executing the oneTBB code <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneTBB/tbb-task-sycl>`_
 
 * **Other**
 
-  * `Compute Fibonacci numbers in different ways <https://github.com/oneapi-src/oneTBB/tree/master/examples/test_all>`_
+  * `Compute Fibonacci numbers in different ways <https://github.com/uxlfoundation/oneTBB/tree/master/examples/test_all>`_
 
 
 .. note:: You can also refer to the `oneAPI Samples <https://oneapi-src.github.io/oneAPI-samples/>`_ to learn more about the ecosystem. 

--- a/doc/GSG/system_requirements.rst
+++ b/doc/GSG/system_requirements.rst
@@ -3,4 +3,4 @@
 System Requirements
 *******************
 
-Refer to the `oneTBB System Requirements <https://github.com/oneapi-src/oneTBB/blob/master/SYSTEM_REQUIREMENTS.md>`_.
+Refer to the `oneTBB System Requirements <https://github.com/uxlfoundation/oneTBB/blob/master/SYSTEM_REQUIREMENTS.md>`_.

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,7 +15,7 @@ Do the following to generate HTML output of the documentation:
 1. Clone oneTBB repository:
 
 ```
-git clone https://github.com/oneapi-src/oneTBB.git
+git clone https://github.com/uxlfoundation/oneTBB.git
 ```
 
 2. Go to the `doc` folder:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,13 +126,13 @@ html_theme = 'sphinx_book_theme'
 
 if BUILD_TYPE == 'dita':
     html_theme_options = {
-        'repository_url': 'https://github.com/oneapi-src/oneTBB',
+        'repository_url': 'https://github.com/uxlfoundation/oneTBB',
         'path_to_docs': 'doc',
         'repository_branch': 'master'
     }
 else:
     html_theme_options = {
-        'repository_url': 'https://github.com/oneapi-src/oneTBB',
+        'repository_url': 'https://github.com/uxlfoundation/oneTBB',
         'path_to_docs': 'doc',
         'use_issues_button': True,
         'use_edit_page_button': True,
@@ -140,7 +140,7 @@ else:
     }
 
 if BUILD_TYPE != 'oneapi' and BUILD_TYPE != 'dita':
-   html_theme_options["extra_footer"]="<div><a href='https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html' data-cookie-notice='true'>Cookies</a> <a href='https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html'>| Privacy</a> <a data-wap_ref='dns' id='wap_dns' href='https://www.intel.com/content/www/us/en/privacy/intel-cookie- notice.html'>| Do Not Share My Personal Information</a> </div><div>&copy; Intel Corporation. Intel, the Intel logo, and other Intel marks are trademarks of Intel Corporation or its subsidiaries. Other names and brands may be claimed as the property of others. No license (express or implied, by estoppel or otherwise) to any intellectual property rights is granted by this document, with the sole exception that code included in this document is licensed subject to the Zero-Clause BSD open source license (OBSD), <a href='http://opensource.org/licenses/0BSD'>http://opensource.org/licenses/0BSD</a>. </div><br><div>oneTBB is licensed under Apache License Version 2.0. Refer to the <a href='https://github.com/oneapi-src/oneTBB/blob/master/LICENSE.txt'>LICENSE </a> file for the full license text and copyright notice.</div>"
+   html_theme_options["extra_footer"]="<div><a href='https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html' data-cookie-notice='true'>Cookies</a> <a href='https://www.intel.com/content/www/us/en/privacy/intel-privacy-notice.html'>| Privacy</a> <a data-wap_ref='dns' id='wap_dns' href='https://www.intel.com/content/www/us/en/privacy/intel-cookie- notice.html'>| Do Not Share My Personal Information</a> </div><div>&copy; Intel Corporation. Intel, the Intel logo, and other Intel marks are trademarks of Intel Corporation or its subsidiaries. Other names and brands may be claimed as the property of others. No license (express or implied, by estoppel or otherwise) to any intellectual property rights is granted by this document, with the sole exception that code included in this document is licensed subject to the Zero-Clause BSD open source license (OBSD), <a href='http://opensource.org/licenses/0BSD'>http://opensource.org/licenses/0BSD</a>. </div><br><div>oneTBB is licensed under Apache License Version 2.0. Refer to the <a href='https://github.com/uxlfoundation/oneTBB/blob/master/LICENSE.txt'>LICENSE </a> file for the full license text and copyright notice.</div>"
 
     
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/doc/main/intro/help_support.rst
+++ b/doc/main/intro/help_support.rst
@@ -12,4 +12,4 @@ Getting Help and Support
 
    For general information about oneTBB technical support, product
    updates, user forums, FAQs, tips and tricks and other support
-   questions, go to `GitHub issues <https://github.com/oneapi-src/oneTBB/issues>`_.
+   questions, go to `GitHub issues <https://github.com/uxlfoundation/oneTBB/issues>`_.

--- a/doc/main/tbb_userguide/std_invoke.rst
+++ b/doc/main/tbb_userguide/std_invoke.rst
@@ -204,14 +204,14 @@ Find More
 
 The following APIs supports Callable object as Bodies: 
 
-* `parallel_for <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_for_func.html>`_
-* `parallel_reduce <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.html>`_
-* `parallel_deterministic_reduce <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_deterministic_reduce_func.html>`_
-* `parallel_for_each <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.html>`_
-* `parallel_scan <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_scan_func.html>`_ 
-* `parallel_pipeline <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_pipeline_func.html>`_ 
-* `function_node <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/func_node_cls.html>`_ 
-* `multifunction_node <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/multifunc_node_cls.html>`_ 
-* `async_node <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/async_node_cls.html>`_ 
-* `sequencer_node <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/sequencer_node_cls.html>`_ 
-* `join_node with key_matching policy <https://oneapi-src.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/join_node_cls.html>`_ 
+* `parallel_for <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_for_func.html>`_
+* `parallel_reduce <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_reduce_func.html>`_
+* `parallel_deterministic_reduce <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_deterministic_reduce_func.html>`_
+* `parallel_for_each <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_for_each_func.html>`_
+* `parallel_scan <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_scan_func.html>`_ 
+* `parallel_pipeline <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/algorithms/functions/parallel_pipeline_func.html>`_ 
+* `function_node <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/func_node_cls.html>`_ 
+* `multifunction_node <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/multifunc_node_cls.html>`_ 
+* `async_node <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/async_node_cls.html>`_ 
+* `sequencer_node <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/sequencer_node_cls.html>`_ 
+* `join_node with key_matching policy <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneTBB/source/flow_graph/join_node_cls.html>`_ 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@ This directory contains example usages of oneAPI Threading Building Blocks.
 
 | Code sample name | Description
 |:--- |:---
-| getting_started/sub_string_finder | Example referenced by the [oneAPI Threading Building Blocks Get Started Guide](https://oneapi-src.github.io/oneTBB/GSG/get_started.html#get-started-guide). Finds the largest matching substrings.
+| getting_started/sub_string_finder | Example referenced by the [oneAPI Threading Building Blocks Get Started Guide](https://uxlfoundation.github.io/oneTBB/GSG/get_started.html#get-started-guide). Finds the largest matching substrings.
 | concurrent_hash_map/count_strings | Concurrently inserts strings into a `concurrent_hash_map` container.
 | concurrent_priority_queue/shortpath | Solves the single source shortest path problem using a  `concurrent_priority_queue` container.
 | graph/binpack | A solution to the binpacking problem using a `queue_node`, a `buffer_node`, and `function_node`s.
@@ -26,7 +26,7 @@ This directory contains example usages of oneAPI Threading Building Blocks.
 | test_all/fibonacci | Compute Fibonacci numbers in different ways.
 
 ## System Requirements
-Refer to the [System Requirements](https://github.com/oneapi-src/oneTBB/blob/master/SYSTEM_REQUIREMENTS.md) for the list of supported hardware and software.
+Refer to the [System Requirements](https://github.com/uxlfoundation/oneTBB/blob/master/SYSTEM_REQUIREMENTS.md) for the list of supported hardware and software.
 
 ### Graphical User Interface (GUI)
 Some examples (e.g., fractal, seismic, tachyon, polygon_overlay) support different GUI modes, which may be defined via the `EXAMPLES_UI_MODE` CMake variable. 

--- a/integration/pkg-config/tbb.pc.in
+++ b/integration/pkg-config/tbb.pc.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Intel Corporation
+# Copyright (c) 2021-2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ includedir=@_includedir_for_pc_file@
 
 Name: oneAPI Threading Building Blocks (oneTBB)
 Description: C++ library for parallel programming on multi-core processors.
-URL: https://github.com/oneapi-src/oneTBB
+URL: https://github.com/uxlfoundation/oneTBB
 Version: @TBB_VERSION@
 Libs: -L${libdir} @_tbb_pc_extra_libdir@ -l@_tbb_pc_lib_name@
 Cflags: -I${includedir}


### PR DESCRIPTION
### Description 
This fixes links to the repo and documentation that got broken after migration to uxlfoundation org.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [X] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
