### PR TITLE
Fix deprecation warning: Compatibility with CMake < 3.10 will be removed from a future version of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+# If the running version of CMake is older than 3.12, the extra ... dots will be seen as version component separators,
+# resulting in the ...<max> part being ignored and preserving the pre-3.12 behavior of basing policies on <min>.
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 # Enable CMake policies
 
@@ -33,6 +35,11 @@ if (POLICY CMP0091)
     cmake_policy(SET CMP0091 NEW)
 elseif (DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
     message(FATAL_ERROR "CMAKE_MSVC_RUNTIME_LIBRARY was defined while policy CMP0091 is not available. Use CMake 3.15 or newer.")
+endif()
+
+if (POLICY CMP0148)
+    # CMake 3.27: The FindPythonInterp and FindPythonLibs modules are removed
+    cmake_policy(SET CMP0148 OLD)
 endif()
 
 if (TBB_WINDOWS_DRIVER AND (NOT ("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL MultiThreaded OR "${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL MultiThreadedDebug)))

--- a/cmake/python/test_launcher.cmake
+++ b/cmake/python/test_launcher.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+if (POLICY CMP0148)
+    # CMake 3.27: The FindPythonInterp and FindPythonLibs modules are removed
+    cmake_policy(SET CMP0148 OLD)
+endif()
 
 find_package(PythonInterp 3.5 REQUIRED)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(tbb_examples CXX)
 

--- a/examples/common/gui/CMakeLists.txt
+++ b/examples/common/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 set(EXAMPLES_UI_MODE "con" CACHE STRING "EXAMPLES_UI_MODE")
 

--- a/examples/concurrent_hash_map/count_strings/CMakeLists.txt
+++ b/examples/concurrent_hash_map/count_strings/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(count_strings CXX)
 

--- a/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
+++ b/examples/concurrent_priority_queue/shortpath/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(shortpath CXX)
 

--- a/examples/getting_started/sub_string_finder/CMakeLists.txt
+++ b/examples/getting_started/sub_string_finder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(sub_string_finder_simple CXX)
 project(sub_string_finder_extended CXX)

--- a/examples/graph/binpack/CMakeLists.txt
+++ b/examples/graph/binpack/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(binpack CXX)
 

--- a/examples/graph/cholesky/CMakeLists.txt
+++ b/examples/graph/cholesky/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(cholesky CXX)
 

--- a/examples/graph/dining_philosophers/CMakeLists.txt
+++ b/examples/graph/dining_philosophers/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(dining_philosophers CXX)
 

--- a/examples/graph/fgbzip2/CMakeLists.txt
+++ b/examples/graph/fgbzip2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(fgbzip2 CXX)
 

--- a/examples/graph/logic_sim/CMakeLists.txt
+++ b/examples/graph/logic_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(logic_sim CXX)
 

--- a/examples/graph/som/CMakeLists.txt
+++ b/examples/graph/som/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 include(../../common/cmake/common.cmake)
 project(som CXX)

--- a/examples/migration/recursive_fibonacci/CMakeLists.txt
+++ b/examples/migration/recursive_fibonacci/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2023-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(recursive_fibonacci CXX)
 

--- a/examples/parallel_for/game_of_life/CMakeLists.txt
+++ b/examples/parallel_for/game_of_life/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(game_of_life CXX)
 

--- a/examples/parallel_for/polygon_overlay/CMakeLists.txt
+++ b/examples/parallel_for/polygon_overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(polygon_overlay CXX)
 

--- a/examples/parallel_for/seismic/CMakeLists.txt
+++ b/examples/parallel_for/seismic/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(seismic CXX)
 

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(tachyon CXX)
 

--- a/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
+++ b/examples/parallel_for_each/parallel_preorder/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(parallel_preorder CXX)
 

--- a/examples/parallel_pipeline/square/CMakeLists.txt
+++ b/examples/parallel_pipeline/square/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(square CXX)
 

--- a/examples/parallel_reduce/convex_hull/CMakeLists.txt
+++ b/examples/parallel_reduce/convex_hull/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(convex_hull_bench CXX)
 project(convex_hull_sample CXX)

--- a/examples/parallel_reduce/pi/CMakeLists.txt
+++ b/examples/parallel_reduce/pi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Intel Corporation
+# Copyright (c) 2023-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(pi CXX)
 

--- a/examples/parallel_reduce/primes/CMakeLists.txt
+++ b/examples/parallel_reduce/primes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(primes CXX)
 

--- a/examples/task_arena/fractal/CMakeLists.txt
+++ b/examples/task_arena/fractal/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(fractal CXX)
 

--- a/examples/task_group/sudoku/CMakeLists.txt
+++ b/examples/task_group/sudoku/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(sudoku CXX)
 

--- a/examples/test_all/fibonacci/CMakeLists.txt
+++ b/examples/test_all/fibonacci/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 Intel Corporation
+# Copyright (c) 2019-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.0...3.31.3)
 
 project(fibonacci CXX)
 


### PR DESCRIPTION

### Description 
Fix CMake deprecation warning:

```
CMake Deprecation Warning at CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

```

https://cmake.org/cmake/help/v3.31/command/cmake_minimum_required.html


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
