### PR TITLE
Fallback to GetThreadGroupAffinity if GetNativeSystemInfo reports wrongly

### DIFF
--- a/src/tbb/misc_ex.cpp
+++ b/src/tbb/misc_ex.cpp
@@ -297,11 +297,21 @@ static void initialize_hardware_concurrency_info () {
         if ( pam & m )
             ++nproc;
     }
-    __TBB_ASSERT( nproc <= (int)si.dwNumberOfProcessors, nullptr);
+    int number_of_processors = (int)si.dwNumberOfProcessors;
+    if (nproc > number_of_processors && TBB_GetThreadGroupAffinity) {
+        // Sometimes on systems with multiple processor groups GetNativeSystemInfo
+        // reports mask and processor count from the parent process
+        TBB_GROUP_AFFINITY ga;
+        if (TBB_GetThreadGroupAffinity( GetCurrentThread(), &ga)) {
+            number_of_processors = (int)TBB_GetActiveProcessorCount(ga.Group);
+        }
+    }
+
+    __TBB_ASSERT( nproc <= number_of_processors, nullptr);
     // By default setting up a number of processors for one processor group
     theProcessorGroups[0].numProcs = theProcessorGroups[0].numProcsRunningTotal = nproc;
     // Setting up processor groups in case the process does not restrict affinity mask and more than one processor group is present
-    if ( nproc == (int)si.dwNumberOfProcessors && TBB_GetActiveProcessorCount ) {
+    if ( nproc == number_of_processors && TBB_GetActiveProcessorCount ) {
         // The process does not have restricting affinity mask and multiple processor groups are possible
         ProcessorGroupInfo::NumGroups = (int)TBB_GetActiveProcessorGroupCount();
         __TBB_ASSERT( ProcessorGroupInfo::NumGroups <= MaxProcessorGroups, nullptr);

--- a/src/tbb/misc_ex.cpp
+++ b/src/tbb/misc_ex.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2024 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -302,7 +302,7 @@ static void initialize_hardware_concurrency_info () {
         // Sometimes on systems with multiple processor groups GetNativeSystemInfo
         // reports mask and processor count from the parent process
         TBB_GROUP_AFFINITY ga;
-        if (TBB_GetThreadGroupAffinity( GetCurrentThread(), &ga)) {
+        if (TBB_GetThreadGroupAffinity(GetCurrentThread(), &ga)) {
             number_of_processors = (int)TBB_GetActiveProcessorCount(ga.Group);
         }
     }


### PR DESCRIPTION
### Description 
For some reason, `GetNativeSystemInfo` on Windows 11 (or WS2022) systems with multiple processor groups reports information from parent process (for example, when running tests using CTest) even though [documentation](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info) states that `dwNumberOfProcessors` is "the number of logical processors in _the current group_". This patch fallbacks to using `GetActiveProcessorCount` on group from calling thread's affinity if possible. 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
