### PR TITLE
Enable Coverity Scan only on uxlfoundation/oneTBB repo

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Intel Corporation
+# Copyright (c) 2024-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ env:
 jobs:
   coverity_linux:
     name: Coverity Linux
+    if: github.repository == 'uxlfoundation/oneTBB'
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description 

To fix CI errors on forks we need to enable Coverity Scan only on main repo.

Error example:
https://github.com/phprus/oneTBB/actions/runs/12580192302/job/35061676517

Or we may use ``repository_id`` instead of ``repository`` name:
```
github.repository_id == '67641996'
```


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@omalyshe

### Other information
