### PR TITLE
Fix the allocator for Flow Graph critical tasks creating

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -526,7 +526,7 @@ inline graph_task* prioritize_task(graph& g, graph_task& gt) {
     //! priority queue, and a new critical task is created to take and execute a work item with
     //! the highest known priority. The reference counting responsibility is transferred to
     //! the new task.
-    // The newly created small_object_allocator should be used to allocate the priority_task_selector
+    // A newly created small_object_allocator should be used to allocate the priority_task_selector
     // instead of the allocator, associated with gt since gt can be allocated by another thread
     d1::small_object_allocator allocator;
     d1::task* critical_task = allocator.new_object<priority_task_selector>(g.my_priority_queue, allocator);

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -526,7 +526,8 @@ inline graph_task* prioritize_task(graph& g, graph_task& gt) {
     //! priority queue, and a new critical task is created to take and execute a work item with
     //! the highest known priority. The reference counting responsibility is transferred to
     //! the new task.
-    d1::task* critical_task = gt.my_allocator.new_object<priority_task_selector>(g.my_priority_queue, gt.my_allocator);
+    d1::small_object_allocator allocator;
+    d1::task* critical_task = allocator.new_object<priority_task_selector>(g.my_priority_queue, allocator);
     __TBB_ASSERT( critical_task, "bad_alloc?" );
     g.my_priority_queue.push(&gt);
     using tbb::detail::d1::submit;

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -526,6 +526,8 @@ inline graph_task* prioritize_task(graph& g, graph_task& gt) {
     //! priority queue, and a new critical task is created to take and execute a work item with
     //! the highest known priority. The reference counting responsibility is transferred to
     //! the new task.
+    // The newly created small_object_allocator should be used to allocate the priority_task_selector
+    // instead of the allocator, associated with gt since gt can be allocated by another thread
     d1::small_object_allocator allocator;
     d1::task* critical_task = allocator.new_object<priority_task_selector>(g.my_priority_queue, allocator);
     __TBB_ASSERT( critical_task, "bad_alloc?" );

--- a/src/tbb/small_object_pool.cpp
+++ b/src/tbb/small_object_pool.cpp
@@ -40,7 +40,8 @@ void* __TBB_EXPORTED_FUNC allocate(d1::small_object_pool*& allocator, std::size_
     // TODO: optimize if the allocator contains a valid pool.
     auto tls = governor::get_thread_data();
     auto pool = tls->my_small_object_pool;
-    __TBB_ASSERT(allocator == nullptr || pool == allocator, "An attempt was made to allocate using another thread's small memory pool");
+    __TBB_ASSERT(allocator == nullptr || pool == allocator,
+                 "An attempt was made to allocate using another thread's small memory pool");
     return pool->allocate_impl(allocator, number_of_bytes);
 }
 

--- a/src/tbb/small_object_pool.cpp
+++ b/src/tbb/small_object_pool.cpp
@@ -40,13 +40,13 @@ void* __TBB_EXPORTED_FUNC allocate(d1::small_object_pool*& allocator, std::size_
     // TODO: optimize if the allocator contains a valid pool.
     auto tls = governor::get_thread_data();
     auto pool = tls->my_small_object_pool;
-    __TBB_ASSERT(allocator == nullptr || pool == allocator,
-                 "An attempt was made to allocate using another thread's small memory pool");
     return pool->allocate_impl(allocator, number_of_bytes);
 }
 
 void* small_object_pool_impl::allocate_impl(d1::small_object_pool*& allocator, std::size_t number_of_bytes)
 {
+    __TBB_ASSERT(allocator == nullptr || allocator == this,
+                 "An attempt was made to allocate using another thread's small memory pool");
     small_object* obj{nullptr};
 
     if (number_of_bytes <= small_object_size) {

--- a/src/tbb/small_object_pool.cpp
+++ b/src/tbb/small_object_pool.cpp
@@ -40,6 +40,7 @@ void* __TBB_EXPORTED_FUNC allocate(d1::small_object_pool*& allocator, std::size_
     // TODO: optimize if the allocator contains a valid pool.
     auto tls = governor::get_thread_data();
     auto pool = tls->my_small_object_pool;
+    __TBB_ASSERT(allocator == nullptr || pool == allocator, "An attempt was made to allocate using another thread's small memory pool");
     return pool->allocate_impl(allocator, number_of_bytes);
 }
 

--- a/src/tbb/small_object_pool.cpp
+++ b/src/tbb/small_object_pool.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2021 Intel Corporation
+    Copyright (c) 2020-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_function_node.cpp
+++ b/test/tbb/test_function_node.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_function_node.cpp
+++ b/test/tbb/test_function_node.cpp
@@ -810,7 +810,7 @@ TEST_CASE("test function_node try_put_and_wait") {
 // It was an issue when the critical task wrapper was allocated using the small object pool
 // of the task being wrapped. Since the original task creates under the aggregator, there is no
 // guarantee that the thread that requested the task creating is the same as actually created the task
-// Mismatch between memory pull caused internal assertion failure while deallocating the task
+// Mismatch between memory pool caused internal assertion failure while deallocating the task
 //! \brief \ref regression
 TEST_CASE("test critical tasks memory pool correctness") {
     using node_type = tbb::flow::function_node<int, tbb::flow::continue_msg>;

--- a/test/tbb/test_function_node.cpp
+++ b/test/tbb/test_function_node.cpp
@@ -806,3 +806,25 @@ TEST_CASE("test function_node try_put_and_wait") {
     test_try_put_and_wait();
 }
 #endif
+
+// It was an issue when the critical task wrapper was allocated using the small object pool
+// of the task being wrapped. Since the original task creates under the aggregator, there is no
+// guarantee that the thread that requested the task creating is the same as actually created the task
+// Mismatch between memory pull caused internal assertion failure while deallocating the task
+//! \brief \ref regression
+TEST_CASE("test critical tasks memory pool correctness") {
+    using node_type = tbb::flow::function_node<int, tbb::flow::continue_msg>;
+    constexpr int num_iterations = 10000;
+    int num_calls = 0;
+    auto node_body = [&](int) { ++num_calls; };
+
+    tbb::flow::graph g;
+    node_type node(g, tbb::flow::serial, node_body, tbb::flow::node_priority_t{1});
+
+    for (int i = 0; i < num_iterations; ++i) {
+        node.try_put(i);
+    }
+
+    g.wait_for_all();
+    REQUIRE_MESSAGE(num_calls == num_iterations, "Incorrect number of body executions");
+}


### PR DESCRIPTION
### Description 
There is a bug in the current implementation of Flow Graph while using functional node concurrency limits together with node priorities.
Current algorithm for creating tasks in function node is the following:
* If the concurrency limit is not reached, two tasks are created - graph_task for executing the body and priority_task_selector task for prioritization. Both tasks are created by the same thread.
* If the concurrency limit is reached, the postponed items are stored in the queue.
* Once the resources of the node are available, the thread X tries to get the postponed item from the queue using the aggregator.
* Since the aggregator is used, another thread Y can take the "aggregated" work and hence, create the graph_task using its small object pool.
* Once the control goes back to thread X, it creates a priority_task_selector wrapper. The bug in the current implementation is that the small object pool, associated with the underlying task (created by thread Y) is used instead of small object pool of thread X.

Also this patch adds extra assert for small object pool to ensure that the pool, for which the allocation is requested is the same as the TLS pool.

Fixes #1595 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
