### PR TITLE
Fix C++20 macro in parallel_for_each + fix concepts macro definition

### DIFF
--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -263,8 +263,8 @@
 #define __TBB_CPP17_ALLOCATOR_IS_ALWAYS_EQUAL_PRESENT   (__TBB_LANG >= 201703L)
 #define __TBB_CPP17_IS_SWAPPABLE_PRESENT                (__TBB_LANG >= 201703L)
 
-// TODO: fix concepts on Apple Clang or define the broken versions
-#if !(__clang__ && __APPLE__) && defined(__cpp_concepts) && defined(__cpp_lib_concepts)
+// TODO: fix concepts on Clang or define the broken versions
+#if !(__clang__) && defined(__cpp_concepts) && defined(__cpp_lib_concepts)
     #define __TBB_CPP20_CONCEPTS_PRESENT ((__cpp_concepts >= 201907L) && (__cpp_lib_concepts >= 202002L))
 #else
     #define __TBB_CPP20_CONCEPTS_PRESENT 0

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -233,10 +233,8 @@
 #if __INTEL_COMPILER && (!_MSC_VER || __INTEL_CXX11_MOVE__)
     #define __TBB_CPP14_VARIABLE_TEMPLATES_PRESENT (__TBB_LANG >= 201402L)
     #define __TBB_CPP17_DEDUCTION_GUIDES_PRESENT   (__INTEL_COMPILER > 2021 && __TBB_LANG >= 201703L)
-    #define __TBB_CPP20_CONCEPTS_PRESENT           0 // TODO: add a mechanism for future addition
 #elif __clang__
     #define __TBB_CPP14_VARIABLE_TEMPLATES_PRESENT (__has_feature(cxx_variable_templates))
-    #define __TBB_CPP20_CONCEPTS_PRESENT           0 // TODO: add a mechanism for future addition
     #ifdef __cpp_deduction_guides
         #define __TBB_CPP17_DEDUCTION_GUIDES_PRESENT (__cpp_deduction_guides >= 201611L)
     #else
@@ -245,15 +243,12 @@
 #elif __GNUC__
     #define __TBB_CPP14_VARIABLE_TEMPLATES_PRESENT (__TBB_LANG >= 201402L && __TBB_GCC_VERSION >= 50000)
     #define __TBB_CPP17_DEDUCTION_GUIDES_PRESENT   (__cpp_deduction_guides >= 201606L)
-    #define __TBB_CPP20_CONCEPTS_PRESENT           (__TBB_LANG >= 201709L && __TBB_GCC_VERSION >= 100201)
 #elif _MSC_VER
     #define __TBB_CPP14_VARIABLE_TEMPLATES_PRESENT (_MSC_FULL_VER >= 190023918 && (!__INTEL_COMPILER || __INTEL_COMPILER >= 1700))
     #define __TBB_CPP17_DEDUCTION_GUIDES_PRESENT   (_MSC_VER >= 1914 && __TBB_LANG >= 201703L && (!__INTEL_COMPILER || __INTEL_COMPILER > 2021))
-    #define __TBB_CPP20_CONCEPTS_PRESENT           (_MSC_VER >= 1923 && __TBB_LANG >= 202002L) // TODO: INTEL_COMPILER?
 #else
     #define __TBB_CPP14_VARIABLE_TEMPLATES_PRESENT (__TBB_LANG >= 201402L)
     #define __TBB_CPP17_DEDUCTION_GUIDES_PRESENT   (__TBB_LANG >= 201703L)
-    #define __TBB_CPP20_CONCEPTS_PRESENT           (__TBB_LANG >= 202002L)
 #endif
 
 // GCC4.8 on RHEL7 does not support std::get_new_handler
@@ -267,6 +262,12 @@
 #define __TBB_CPP17_LOGICAL_OPERATIONS_PRESENT          (__TBB_LANG >= 201703L)
 #define __TBB_CPP17_ALLOCATOR_IS_ALWAYS_EQUAL_PRESENT   (__TBB_LANG >= 201703L)
 #define __TBB_CPP17_IS_SWAPPABLE_PRESENT                (__TBB_LANG >= 201703L)
+
+#if defined(__cpp_concepts) && defined(__cpp_lib_concepts)
+    #define __TBB_CPP20_CONCEPTS_PRESENT ((__cpp_concepts >= 201907L) && (__cpp_lib_concepts >= 202002L))
+#else
+    #define __TBB_CPP20_CONCEPTS_PRESENT 0
+#endif
 
 #if defined(__cpp_impl_three_way_comparison) && defined(__cpp_lib_three_way_comparison)
     #define __TBB_CPP20_COMPARISONS_PRESENT ((__cpp_impl_three_way_comparison >= 201907L) && (__cpp_lib_three_way_comparison >= 201907L))

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -263,7 +263,8 @@
 #define __TBB_CPP17_ALLOCATOR_IS_ALWAYS_EQUAL_PRESENT   (__TBB_LANG >= 201703L)
 #define __TBB_CPP17_IS_SWAPPABLE_PRESENT                (__TBB_LANG >= 201703L)
 
-#if defined(__cpp_concepts) && defined(__cpp_lib_concepts)
+// TODO: fix concepts on Apple Clang or define the broken versions
+#if !(__clang__ && __APPLE__) && defined(__cpp_concepts) && defined(__cpp_lib_concepts)
     #define __TBB_CPP20_CONCEPTS_PRESENT ((__cpp_concepts >= 201907L) && (__cpp_lib_concepts >= 202002L))
 #else
     #define __TBB_CPP20_CONCEPTS_PRESENT 0

--- a/include/oneapi/tbb/detail/_range_common.h
+++ b/include/oneapi/tbb/detail/_range_common.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -102,20 +102,23 @@ concept tbb_range = std::copy_constructible<Range> &&
                         { range.is_divisible() } -> relaxed_convertible_to<bool>;
                     };
 
+template <typename Iterator, typename IteratorTag>
+struct iterator_concept_helper;
+
+// New specializations should be added in case of using container_based_sequence with
+// the new iterator tag types
 template <typename Iterator>
-constexpr bool iterator_concept_helper( std::input_iterator_tag ) {
-    return std::input_iterator<Iterator>;
-}
+struct iterator_concept_helper<Iterator, std::input_iterator_tag> {
+    static constexpr bool value = std::input_iterator<Iterator>;
+};
 
 template <typename Iterator>
-constexpr bool iterator_concept_helper( std::random_access_iterator_tag ) {
-    return std::random_access_iterator<Iterator>;
-}
+struct iterator_concept_helper<Iterator, std::random_access_iterator_tag> {
+    static constexpr bool value = std::random_access_iterator<Iterator>;
+};
 
 template <typename Iterator, typename IteratorTag>
-concept iterator_satisfies = requires (IteratorTag tag) {
-    requires iterator_concept_helper<Iterator>(tag);
-};
+concept iterator_satisfies = iterator_concept_helper<Iterator, IteratorTag>::value;
 
 template <typename Sequence, typename IteratorTag>
 concept container_based_sequence = requires( Sequence& seq ) {

--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/flow_graph.h
+++ b/include/oneapi/tbb/flow_graph.h
@@ -85,7 +85,7 @@ class continue_msg {};
 } // namespace d2
 
 #if __TBB_CPP20_CONCEPTS_PRESENT
-namespace d0 {
+inline namespace d0 {
 
 template <typename ReturnType, typename OutputType>
 concept node_body_return_type = std::same_as<OutputType, tbb::detail::d2::continue_msg> ||
@@ -127,7 +127,7 @@ template <typename Body, typename Input, typename GatewayType>
 concept async_node_body = std::copy_constructible<Body> &&
                           std::invocable<Body&, const Input&, GatewayType&>;
 
-} // namespace d0
+} // inline namespace d0
 #endif // __TBB_CPP20_CONCEPTS_PRESENT
 
 namespace d2 {

--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -409,7 +409,7 @@ public:
 template<typename It>
 using tag = typename std::iterator_traits<It>::iterator_category;
 
-#if __TBB_CPP20_PRESENT
+#if __TBB_CPP20_CONCEPTS_PRESENT
 template <typename It>
 struct move_iterator_dispatch_helper {
     using type = It;
@@ -448,7 +448,7 @@ using iterator_tag_dispatch = typename
             std::input_iterator_tag
         >::type
     >::type;
-#endif // __TBB_CPP20_PRESENT
+#endif // __TBB_CPP20_CONCEPTS_PRESENT
 
 template <typename Body, typename Iterator, typename Item>
 using feeder_is_required = tbb::detail::void_t<decltype(tbb::detail::invoke(std::declval<const Body>(),

--- a/include/oneapi/tbb/parallel_for_each.h
+++ b/include/oneapi/tbb/parallel_for_each.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/parallel_scan.h
+++ b/include/oneapi/tbb/parallel_scan.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ struct sum_node;
 
 #if __TBB_CPP20_CONCEPTS_PRESENT
 } // namespace d1
-namespace d0 {
+inline namespace d0 {
 
 template <typename Body, typename Range>
 concept parallel_scan_body = splittable<Body> &&

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -385,7 +385,7 @@ struct ParallelScanFunction {
     T operator()( Dummy, const T& a, bool ) const requires (EnableFunctionCallOperator == State::incorrect_first_input) { return a; }
     T operator()( const Range&, Dummy, bool ) const requires (EnableFunctionCallOperator == State::incorrect_second_input) { return T{}; }
     T operator()( const Range&, const T& a, Dummy ) const requires (EnableFunctionCallOperator == State::incorrect_third_input) { return a; }
-    Dummy operator()( const Range&, const T& a, bool ) const requires (EnableFunctionCallOperator == State::incorrect_return_type) { return Dummy{}; }
+    Dummy operator()( const Range&, const T&, bool ) const requires (EnableFunctionCallOperator == State::incorrect_return_type) { return Dummy{}; }
 };
 
 template <typename R, typename T> using Correct = ParallelScanFunction<R, T, /*() = */State::correct>;

--- a/test/common/concepts_common.h
+++ b/test/common/concepts_common.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2021 Intel Corporation
+    Copyright (c) 2021-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -22,7 +22,7 @@
 //! \file test_parallel_for_each.cpp
 //! \brief Test for [algorithms.parallel_for_each]
 
-#if __TBB_CPP20_PRESENT
+#if __TBB_CPP20_CONCEPTS_PRESENT
 // Fancy iterator type that models the C++20 iterator type
 // that defines the real iterator category using iterator_concept type
 // and iterator_category is always std::input_iterator_type
@@ -119,7 +119,7 @@ struct cpp20_iterator {
 private:
     T* my_ptr = nullptr;
 }; // class cpp20_iterator
-#endif // __TBB_CPP20_PRESENT
+#endif // __TBB_CPP20_CONCEPTS_PRESENT
 
 //! Test forward access iterator support
 //! \brief \ref error_guessing \ref interface
@@ -328,4 +328,4 @@ TEST_CASE("parallel_for_each with cpp20 iterator") {
     test_with_cpp20_iterator<std::random_access_iterator_tag>();
 }
 
-#endif // __TBB_CPP20_PRESENT
+#endif // __TBB_CPP20_CONCEPTS_PRESENT

--- a/test/tbb/test_parallel_for_each.cpp
+++ b/test/tbb/test_parallel_for_each.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2023 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -269,10 +269,6 @@ TEST_CASE("parallel_for_each constraints") {
     test_pfor_each_container_based_sequence_constraints();
     test_pfor_each_body_constraints();
 }
-
-#endif // __TBB_CPP20_CONCEPTS_PRESENT
-
-#if __TBB_CPP20_PRESENT
 
 struct no_copy_move {
     no_copy_move() = default;


### PR DESCRIPTION
### Description 
_Add a comprehensive description of proposed changes_

Fix two issues:
* parallel_for_each failed to compile on gcc9 since __TBB_CPP20_PRESENT was while STL concepts were used actually. Changed to __TBB_CPP20_CONCEPTS_PRESENT
* __TBB_CPP20_CONCEPTS_PRESENT macro was always defined to 0 for Intel Compiler and Clang. Changed to the detection based on Standard feature-test macros (the same approach as previously used for three-way-comparison)

Fixes #1552 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
