### PR TITLE
Fix legacy *.lib files not obeying CMAKE_INSTALL_LIBDIR variable.

### DIFF
--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 Intel Corporation
+# Copyright (c) 2020-2025 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/tbb/CMakeLists.txt
+++ b/src/tbb/CMakeLists.txt
@@ -163,7 +163,7 @@ if (TBB_INSTALL)
         # to support previous user experience for linkage.
         install(FILES
                 $<TARGET_LINKER_FILE:tbb>
-                DESTINATION lib
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 CONFIGURATIONS RelWithDebInfo Release MinSizeRel
                 RENAME tbb.lib
                 COMPONENT devel
@@ -171,7 +171,7 @@ if (TBB_INSTALL)
 
         install(FILES
                 $<TARGET_LINKER_FILE:tbb>
-                DESTINATION lib
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 CONFIGURATIONS Debug
                 RENAME tbb_debug.lib
                 COMPONENT devel
@@ -180,7 +180,7 @@ if (TBB_INSTALL)
     if(TBB_LINUX_SEPARATE_DBG)
         install(FILES
                 $<TARGET_FILE:tbb>.dbg
-                DESTINATION lib
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT devel
         )
     endif()


### PR DESCRIPTION
### Description 
This simple fix replaces hard-coded "lib" literals on legacy .lib file installations. Similarly, it also changes the destination of .dbg file (when debug information is separated from the .so).

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [x] Yes (debatable but yes?, somewhere someone probably explicitly fixed this and their code will break maybe)
- [ ] No
- [ ] Unknown

### Notify the following users

### Other information
