### PR TITLE
Fix UBSan issue

### DIFF
--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -469,6 +469,8 @@ private:
     hash_map_iterator( const Container &map, std::size_t index, const bucket *b, node_base *n ) :
         my_map(&map), my_index(index), my_bucket(b), my_node(nullptr)
     {
+        // Cannot directly initialize to n, because it could be an invalid node pointer (e.g., when
+        // setting a midpoint for a 1-element range). If it is, try one from a subsequent bucket.
         if( map_base::is_valid(n) )
             my_node = static_cast<node*>(n);
         else if( b )

--- a/include/oneapi/tbb/concurrent_hash_map.h
+++ b/include/oneapi/tbb/concurrent_hash_map.h
@@ -467,9 +467,11 @@ private:
     friend class concurrent_hash_map;
 
     hash_map_iterator( const Container &map, std::size_t index, const bucket *b, node_base *n ) :
-        my_map(&map), my_index(index), my_bucket(b), my_node(static_cast<node*>(n))
+        my_map(&map), my_index(index), my_bucket(b), my_node(nullptr)
     {
-        if( b && !map_base::is_valid(n) )
+        if( map_base::is_valid(n) )
+            my_node = static_cast<node*>(n);
+        else if( b )
             advance_to_next_bucket();
     }
 


### PR DESCRIPTION
### Description 
UBSan reports an error if we try to downcast a misaligned address. To avoid it, we need to check if an address is valid before casting it.

Here is the UBSan error:
```
concurrent_hash_map.h:470:62: runtime error: downcast of misaligned address 0x000000000003 for type 'node' (aka 'tbb::detail::d2::concurrent_hash_map<int, int>::node'), which requires 8 byte alignment
0x000000000003: note: pointer points here
<memory cannot be printed>
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior concurrent_hash_map.h:470:62
```

Fixes #1601

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown