### PR TITLE
Update build instructions for WASM

### DIFF
--- a/WASM_Support.md
+++ b/WASM_Support.md
@@ -33,7 +33,7 @@ To build the system, run:
 
 ```
 mkdir build && cd build
-emcmake cmake .. -DCMAKE_CXX_COMPILER=em++ -DCMAKE_C_COMPILER=emcc -DTBB_STRICT=OFF -DCMAKE_CXX_FLAGS=-Wno-unused-command-line-argument -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON -DBUILD_SHARED_LIBS=ON -DTBB_EXAMPLES=ON -DTBB_TEST=ON
+emcmake cmake .. -DCMAKE_CXX_COMPILER=em++ -DCMAKE_C_COMPILER=emcc -DTBB_STRICT=OFF -DCMAKE_CXX_FLAGS=-Wno-unused-command-line-argument -DTBB_DISABLE_HWLOC_AUTOMATIC_SEARCH=ON -DBUILD_SHARED_LIBS=OFF -DTBB_EXAMPLES=ON -DTBB_TEST=ON
 ```
 To compile oneTBB without ``pthreads``, set the flag ``-DEMSCRIPTEN_WITHOUT_PTHREAD=true`` in the command above. By default, oneTBB uses the ``pthreads``.
 ```


### PR DESCRIPTION
### Description 
Emscripten uses static linking, so we should explicitly request a static TBB library instead of

* explicitly asking for shared (current instructions)
* using the default, i.e., shared

Both of the above get overridden with multiple warnings.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown