### PR TITLE
Ignore system-wide installed HWLOC for test/conformance_arena_constraints

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -282,10 +282,18 @@ function(tbb_add_tbbbind_test)
     endif()
     ProcessorCount(SYSTEM_CONCURRENCY)
 
+    if (UNIX AND NOT TARGET stubhwloc)
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "int main(){}")
+        add_library(stubhwloc SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)
+        set_target_properties(stubhwloc PROPERTIES OUTPUT_NAME "hwloc" SOVERSION 15)
+    endif()
+
     set_tests_properties(${_tbbbind_test_NAME} PROPERTIES
         PASS_REGULAR_EXPRESSION "oneTBB: TBBBIND.*UNAVAILABLE"
         FAIL_REGULAR_EXPRESSION "Status:.*FAILURE"
     )
+
+    target_link_libraries(${_tbbbind_test_NAME} PRIVATE stubhwloc)
 
     if (TARGET HWLOC::hwloc_2_5 AND NOT HWLOC_2_5_TESTS_STATUS_SHOWN)
         message(STATUS "HWLOC 2.5 dependent tests were enabled.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -282,10 +282,14 @@ function(tbb_add_tbbbind_test)
     endif()
     ProcessorCount(SYSTEM_CONCURRENCY)
 
-    if (UNIX AND NOT TARGET stubhwloc)
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "int main(){}")
-        add_library(stubhwloc SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)
-        set_target_properties(stubhwloc PROPERTIES OUTPUT_NAME "hwloc" SOVERSION 15)
+    if (UNIX NOT TARGET HWLOC::hwloc_stub AND NOT TBB_TCM_TESTING)
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "void hwloc_stub(){}")
+        add_library(hwloc_stub SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)
+        add_library(HWLOC::hwloc_stub ALIAS hwloc_stub)
+
+        set_target_properties(hwloc_stub PROPERTIES
+            OUTPUT_NAME "hwloc" SOVERSION 15
+        )
     endif()
 
     set_tests_properties(${_tbbbind_test_NAME} PROPERTIES
@@ -293,7 +297,15 @@ function(tbb_add_tbbbind_test)
         FAIL_REGULAR_EXPRESSION "Status:.*FAILURE"
     )
 
-    target_link_libraries(${_tbbbind_test_NAME} PRIVATE stubhwloc)
+    if (TARGET HWLOC::hwloc_stub)
+        _tbb_get_hwloc_runtime_vars(
+            ENV_EXTENSION_VARIABLE HWLOC_RUNTIME_VARS
+            HWLOC_VERSION_LIST "hwloc_stub"
+        )
+        target_link_libraries(${_tbbbind_test_NAME} PRIVATE HWLOC::hwloc_stub)
+
+        set_property(TEST ${_tbbbind_test_NAME} PROPERTY ENVIRONMENT "${HWLOC_RUNTIME_VARS}" APPEND)
+    endif()
 
     if (TARGET HWLOC::hwloc_2_5 AND NOT HWLOC_2_5_TESTS_STATUS_SHOWN)
         message(STATUS "HWLOC 2.5 dependent tests were enabled.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -284,6 +284,9 @@ function(tbb_add_tbbbind_test)
 
     # Make sure fake HWLOC is found before system one
     if (UNIX AND NOT TARGET HWLOC::hwloc_stub AND NOT TBB_TCM_TESTING)
+        # The idea is to produce fake HWLOC library and link it with the test
+        # to ensure that TBBBind won't be loaded in order to simulate the case
+        # when real HWLOC is not present in the system.
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "void hwloc_stub(){}")
         add_library(hwloc_stub SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)
         add_library(HWLOC::hwloc_stub ALIAS hwloc_stub)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -282,7 +282,7 @@ function(tbb_add_tbbbind_test)
     endif()
     ProcessorCount(SYSTEM_CONCURRENCY)
 
-    if (UNIX NOT TARGET HWLOC::hwloc_stub AND NOT TBB_TCM_TESTING)
+    if (UNIX AND NOT TARGET HWLOC::hwloc_stub AND NOT TBB_TCM_TESTING)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "void hwloc_stub(){}")
         add_library(hwloc_stub SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)
         add_library(HWLOC::hwloc_stub ALIAS hwloc_stub)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -282,6 +282,7 @@ function(tbb_add_tbbbind_test)
     endif()
     ProcessorCount(SYSTEM_CONCURRENCY)
 
+    # Make sure fake HWLOC is found before system one
     if (UNIX AND NOT TARGET HWLOC::hwloc_stub AND NOT TBB_TCM_TESTING)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp "void hwloc_stub(){}")
         add_library(hwloc_stub SHARED ${CMAKE_CURRENT_BINARY_DIR}/stubhwloc.cpp)


### PR DESCRIPTION
### Description

When HWLOC targets are explicitly defined, multiple tests cases are enabled to validate different environments (different hwloc versions, conflicting hwloc versions), including the case, when HWLOC is not available (`test/conformance_arena_constraints` without any suffixes).

But it is very likely that HWLOC can be installed system-wide on Unix-like systems using package managers. To ignore these system-wide libraries we can explicitly link `test/conformance_arena_constraints` to stub version of HWLOC.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
