### PR TITLE
Suppress Intel Compiler deprecation warning for STL in test_allocators.cpp

### DIFF
--- a/test/tbb/test_allocators.cpp
+++ b/test/tbb/test_allocators.cpp
@@ -14,6 +14,14 @@
     limitations under the License.
 */
 
+#include <tbb/version.h>
+#define TEST_BROKEN __INTEL_LLVM_COMPILER == 20250000 && __TBB_GLIBCXX_VERSION == 110000 && __TBB_CPP20_PRESENT
+
+#if TEST_BROKEN
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "tbb/cache_aligned_allocator.h"
 #include "tbb/tbb_allocator.h"
 
@@ -98,5 +106,9 @@ TEST_CASE("polymorphic_allocator test") {
             "Cache aligned resource upstream shouldn't be equal to the standard resource.");
     TestAllocatorWithSTL(std::pmr::polymorphic_allocator<void>(&aligned_resource));
 }
+#endif
+
+#if TEST_BROKEN
+#pragma clang diagnostic pop // "-Wdeprecated-declarations"
 #endif
 

--- a/test/tbb/test_allocators.cpp
+++ b/test/tbb/test_allocators.cpp
@@ -14,10 +14,13 @@
     limitations under the License.
 */
 
-#include <tbb/version.h>
-#define TEST_BROKEN __INTEL_LLVM_COMPILER == 20250000 && __TBB_GLIBCXX_VERSION == 110000 && __TBB_CPP20_PRESENT
+#include <tbb/version.h> // For __TBB_GLIBCXX_VERSION and __TBB_CPP20_PRESENT
 
-#if TEST_BROKEN
+// Intel LLVM compiler triggers a deprecation warning in the implementation of std::allocator_traits::destroy
+// inside Standard Library while using STL PMR containers since std::polymorphic_allocator::destroy is deprecated since C++20
+#define TEST_LLVM_COMPILER_PMR_DESTROY_DEPRECATED_BROKEN __INTEL_LLVM_COMPILER == 20250000 && __TBB_GLIBCXX_VERSION == 110000 && __TBB_CPP20_PRESENT
+
+#if TEST_LLVM_COMPILER_PMR_DESTROY_DEPRECATED_BROKEN
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -108,7 +111,6 @@ TEST_CASE("polymorphic_allocator test") {
 }
 #endif
 
-#if TEST_BROKEN
+#if TEST_LLVM_COMPILER_PMR_DESTROY_DEPRECATED_BROKEN
 #pragma clang diagnostic pop // "-Wdeprecated-declarations"
 #endif
-

--- a/test/tbb/test_allocators.cpp
+++ b/test/tbb/test_allocators.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description 
Intel LLVM compiler triggers a warning for deprecated `std::pmr::polymorphic_allocator::destroy` inside the implementation of `std::allocator_traits::destroy` method. Since this method is not used explicitly by the user, I think the warning should not be triggered and this can be considered a compiler issue. 
Suppressed the warning on the affected platform. 


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
