### PR TITLE
Suppress Intel Compiler debug iterator vectorization warning in test_openmp.cpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -535,6 +535,8 @@ if (TARGET TBB::tbb)
 
         set_target_properties(test_openmp PROPERTIES COMPILE_FLAGS ${TBB_OPENMP_FLAG})
 
+        # Intel LLVM compiler triggers a warning when using OpenMP in debug mode on Windows.
+        # The only way not to trigger it seems to be explicitly disabling it from the command line.
         if (WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM) AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 2025.0))
             target_compile_options(test_openmp PRIVATE $<$<CONFIG:DEBUG>:-Wno-debug-option-simd>)
         endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -535,6 +535,10 @@ if (TARGET TBB::tbb)
 
         set_target_properties(test_openmp PROPERTIES COMPILE_FLAGS ${TBB_OPENMP_FLAG})
 
+        if (WIN32 AND (CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM) AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 2025.0))
+            target_compile_options(test_openmp PRIVATE $<$<CONFIG:DEBUG>:-Wno-debug-option-simd>)
+        endif()
+
         if (NOT TBB_OPENMP_NO_LINK_FLAG)
             set_target_properties(test_openmp PROPERTIES LINK_FLAGS ${TBB_OPENMP_FLAG})
         endif()


### PR DESCRIPTION
### Description 
Intel LLVM compiler triggers a warning when using OpenMP in debug mode on Windows:
```
using /MTd or /MDd with '#pragma omp simd' may lead to unexpected fails due to the debugging version of iterators that cannot be vectorized correctly [-Wdebug-option-simd]
```
This happens even when vectorization is turned off with `/Qopenmp-simd-`. In fact, the only way not to trigger the warning seems to be explicitly disabling it. Since `test_openmp.cpp` does not use vectorization, the warning should not be triggered and this can be considered a compiler issue.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [x] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
