### PR TITLE
Fix uninitialized variables in copy_counting_object

### DIFF
--- a/test/conformance/conformance_flowgraph.h
+++ b/test/conformance/conformance_flowgraph.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2020-2023 Intel Corporation
+    Copyright (c) 2020-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/conformance/conformance_flowgraph.h
+++ b/test/conformance/conformance_flowgraph.h
@@ -346,9 +346,10 @@ struct copy_counting_object {
         copy_count(0), copies_count(0), assign_count(0), is_copy(false) {}
 
     copy_counting_object( const copy_counting_object<OutputType, InputType>& other ):
-        copy_count(other.copy_count + 1), is_copy(true) {
-            ++other.copies_count;
-        }
+        copy_count(other.copy_count + 1), copies_count(0), assign_count(0), is_copy(true)
+    {
+        ++other.copies_count;
+    }
 
     copy_counting_object& operator=( const copy_counting_object<OutputType, InputType>& other ) {
         assign_count = other.assign_count + 1;


### PR DESCRIPTION
### Description 
Fix High impact [Uninitialized scalar variable](https://scan4.scan.coverity.com/doc/en/cov_checker_ref.html#static_checker_UNINIT) coverity hit.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
