### PR TITLE
Example Benchmarks: calculate relative error on repeats

### DIFF
--- a/examples/common/utility/measurements.hpp
+++ b/examples/common/utility/measurements.hpp
@@ -31,17 +31,25 @@ public:
     measurements() = default;
 
     measurements(unsigned iterations) {
-        _time_intervals.reserve(iterations);
+        _iterations = iterations;
+        _time_intervals.reserve(_iterations);
+    }
+
+    inline unsigned iterations() {
+        return _iterations;
     }
 
     inline void start() {
         _startTime = std::chrono::steady_clock::now();
     }
-    inline void stop() {
+
+    inline std::chrono::microseconds stop() {
         auto _endTime = std::chrono::steady_clock::now();
         // store the end time and start time
         _time_intervals.push_back(std::make_pair(_startTime, _endTime));
+        return std::chrono::duration_cast<std::chrono::microseconds>(_endTime - _startTime);
     }
+
     double computeRelError() {
         // Accumulate the total duration in microseconds using std::accumulate with a lambda function
         assert(0 != _time_intervals.size());
@@ -76,6 +84,7 @@ private:
     using time_point = std::chrono::steady_clock::time_point;
     time_point _startTime;
     std::vector<std::pair<time_point, time_point>> _time_intervals;
+    unsigned _iterations;
 };
 
 } // namespace utility

--- a/examples/common/utility/measurements.hpp
+++ b/examples/common/utility/measurements.hpp
@@ -1,0 +1,83 @@
+/*
+    Copyright (c) 2005-2025 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef TBB_examples_measurements_H
+#define TBB_examples_measurements_H
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <numeric>
+#include <vector>
+
+namespace utility {
+
+// utility class to aid relative error measurement of samples
+class measurements {
+public:
+    measurements() = default;
+
+    measurements(unsigned iterations) {
+        _time_intervals.reserve(iterations);
+    }
+
+    inline void start() {
+        _startTime = std::chrono::steady_clock::now();
+    }
+    inline void stop() {
+        auto _endTime = std::chrono::steady_clock::now();
+        // store the end time and start time
+        _time_intervals.push_back(std::make_pair(_startTime, _endTime));
+    }
+    double computeRelError() {
+        // Accumulate the total duration in microseconds using std::accumulate with a lambda function
+        assert(0 != _time_intervals.size());
+        auto total_duration = std::accumulate(
+            _time_intervals.begin(),
+            _time_intervals.end(),
+            0, // Start with 0 count
+            [](long long total, const std::pair<time_point, time_point>& interval) {
+                // Compute the difference and add it to the total
+                return total + std::chrono::duration_cast<std::chrono::microseconds>(
+                                   interval.second - interval.first)
+                                   .count();
+            });
+        unsigned long long averageTimePerFrame = total_duration / _time_intervals.size();
+        unsigned long long sumOfSquareDiff = 0;
+        std::for_each(_time_intervals.begin(),
+                      _time_intervals.end(),
+                      [&](const std::pair<time_point, time_point>& interval) {
+                          unsigned long long duration =
+                              std::chrono::duration_cast<std::chrono::microseconds>(
+                                  interval.second - interval.first)
+                                  .count();
+                          long long diff = duration - averageTimePerFrame;
+                          sumOfSquareDiff += diff * diff;
+                      });
+        double stdDev = std::sqrt(sumOfSquareDiff / _time_intervals.size());
+        double relError = 100 * (stdDev / averageTimePerFrame);
+        return relError;
+    }
+
+private:
+    using time_point = std::chrono::steady_clock::time_point;
+    time_point _startTime;
+    std::vector<std::pair<time_point, time_point>> _time_intervals;
+};
+
+} // namespace utility
+
+#endif /* TBB_examples_measurements_H */

--- a/examples/common/utility/utility.hpp
+++ b/examples/common/utility/utility.hpp
@@ -549,9 +549,10 @@ inline void report_skipped() {
               << "\n";
 }
 
-inline void report_relative_error(double err) {
-    std::cout << "Relative_Err : " << err << " %"
-              << "\n";
+inline void report_relative_error(double err,
+                                  const std::string& prefix = "Relative_Err : ",
+                                  const std::string& suffix = " %") {
+    std::cout << prefix << err << suffix << std::endl;
 }
 
 inline void parse_cli_arguments(int argc, const char* argv[], utility::cli_argument_pack cli_pack) {

--- a/examples/common/utility/utility.hpp
+++ b/examples/common/utility/utility.hpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -357,59 +357,6 @@ public:
         return str.str();
     }
 }; // class cli_argument_pack
-
-// utility class to aid relative error measurement of samples
-class measurements {
-public:
-    measurements() = default;
-
-    measurements(unsigned iterations) {
-        _time_intervals.reserve(iterations);
-    }
-
-    inline void start() {
-        _startTime = std::chrono::steady_clock::now();
-    }
-    inline void stop() {
-        auto _endTime = std::chrono::steady_clock::now();
-        // store the end time and start time
-        _time_intervals.push_back(std::make_pair(_startTime, _endTime));
-    }
-    double computeRelError() {
-        // Accumulate the total duration in microseconds using std::accumulate with a lambda function
-        assert(0 != _time_intervals.size());
-        auto total_duration = std::accumulate(
-            _time_intervals.begin(),
-            _time_intervals.end(),
-            0, // Start with 0 count
-            [](long long total, const std::pair<time_point, time_point>& interval) {
-                // Compute the difference and add it to the total
-                return total + std::chrono::duration_cast<std::chrono::microseconds>(
-                                   interval.second - interval.first)
-                                   .count();
-            });
-        unsigned long long averageTimePerFrame = total_duration / _time_intervals.size();
-        unsigned long long sumOfSquareDiff = 0;
-        std::for_each(_time_intervals.begin(),
-                      _time_intervals.end(),
-                      [&](const std::pair<time_point, time_point>& interval) {
-                          unsigned long long duration =
-                              std::chrono::duration_cast<std::chrono::microseconds>(
-                                  interval.second - interval.first)
-                                  .count();
-                          long long diff = duration - averageTimePerFrame;
-                          sumOfSquareDiff += diff * diff;
-                      });
-        double stdDev = std::sqrt(sumOfSquareDiff / _time_intervals.size());
-        double relError = 100 * (stdDev / averageTimePerFrame);
-        return relError;
-    }
-
-private:
-    using time_point = std::chrono::steady_clock::time_point;
-    time_point _startTime;
-    std::vector<std::pair<time_point, time_point>> _time_intervals;
-};
 
 namespace internal {
 template <typename T>

--- a/examples/parallel_for/seismic/main.cpp
+++ b/examples/parallel_for/seismic/main.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include "oneapi/tbb/global_control.h"
 
 #include "common/utility/utility.hpp"
+#include "common/utility/measurements.hpp"
 #include "common/utility/get_default_num_threads.hpp"
 
 #include "seismic_video.hpp"

--- a/examples/parallel_for/tachyon/README.md
+++ b/examples/parallel_for/tachyon/README.md
@@ -34,6 +34,7 @@ tachyon [dataset=value] [boundthresh=value] [no-display-updating] [no-bounding] 
 * `boundthresh` - bounding threshold value.
 * `no-display-updating` - disable run-time display updating.
 * `no-bounding` - disable bounding technique.
+* `n-of-repeats` - how many times to repeat rendering to collect its reliable performance statistics.
 
 ### Environment variables
 The `tbb` and `tbb1d` version of examples has the following settings that may be handled by environment variables:

--- a/examples/parallel_for/tachyon/src/tachyon_video.cpp
+++ b/examples/parallel_for/tachyon/src/tachyon_video.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2021 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@
     SUCH DAMAGE.
 */
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -53,27 +54,39 @@
 #include "util.hpp"
 #include "tachyon_video.hpp"
 
+#include "common/utility/measurements.hpp"
+
 extern SceneHandle global_scene;
 extern char *global_window_title;
 extern bool global_usegraphics;
+extern utility::measurements *global_measurements;
 
 void tachyon_video::on_process() {
     char buf[8192];
     flt runtime;
+    unsigned iterations = global_measurements->iterations();
     scenedef *scene = (scenedef *)global_scene;
     updating_mode = scene->displaymode == RT_DISPLAY_ENABLED;
-    recycling = false;
     pausing = false;
     do {
+        recycling = false;
         updating = updating_mode;
-        timer start_timer = gettimer();
+        global_measurements->start();
         rt_renderscene(global_scene);
-        timer end_timer = gettimer();
-        runtime = timertime(start_timer, end_timer);
-        sprintf(buf, "%s: %.3f seconds", global_window_title, runtime);
+        auto duration_usec = global_measurements->stop().count();
+        sprintf(buf,
+                "%s: %.3f seconds",
+                global_window_title,
+                (double)duration_usec / std::chrono::microseconds(std::chrono::seconds(1)).count());
         rt_ui_message(MSG_0, buf);
         title = buf;
         show_title(); // show time spent for rendering
+
+        iterations--;
+        if (iterations > 0) {
+            updating = false;
+            recycling = true;
+        }
         if (!updating) {
             updating = true;
             drawing_memory dm = get_drawing_memory();

--- a/examples/parallel_reduce/primes/README.md
+++ b/examples/parallel_reduce/primes/README.md
@@ -21,5 +21,5 @@ primes [n-of-threads=value] [number=value] [grain-size=value] [n-of-repeats=valu
 * `n-of-threads` - the number of threads to use; a range of the form low\[:high\], where low and optional high are non-negative integers or `auto` for a platform-specific default number.
 * `number` - the upper bound of range to search primes in, must be a positive integer.
 * `grain-size` - the optional grain size, must be a positive integer.
-* `n-of-repeats` - the number of the calculation repeats, must be a positive integer.
-* `silent` - no output except elapsed time.
+* `n-of-repeats` - the number of the calculation repeats, must be a positive integer; when it is greater than 1 then relative error will be calculated for them.
+* `silent` - no output except elapsed time and relative errors.

--- a/examples/task_group/sudoku/README.md
+++ b/examples/task_group/sudoku/README.md
@@ -22,8 +22,9 @@ sudoku [n-of-threads=value] [filename=value] [verbose] [silent] [find-one] [-h] 
 * `-h` - prints the help for command line options.
 * `n-of-threads` - the number of threads to use; a range of the form low\[:high\], where low and optional high are non-negative integers or `auto` for a platform-specific default number.
 * `filename` - the input filename.
+* `n-of-repeats` - the number of repeats to find the same solution; when it is greater than 1 then relative error will be calculated for the repeats.
 * `verbose` - prints the first solution.
-* `silent` - no output except elapsed time.
+* `silent` - no output except elapsed time and relative errors.
 * `find-one` - stops after finding first solution.
 
 The example's directory contains following files that may be used as an input file:


### PR DESCRIPTION
### Description 

Extend the `Tachyon` example with additional command line option `n-of-iterations` to execute ray tracing (rendering) several times and collect its performance metrics to estimate relative error (for rendering duration at the moment).

Extend the `Primes` example's `n-of-repeats` execution mode to calculate relative error for each of the parallel threads
execution block (`n-of-threads`), so it is now possible to measure their performance reliability.

Extend the `Sudoku` example with additional option to repeat solution several times and calculate relative error to estimate performance reliability.

The relative error allows to take informed decision on how reliable and reproduceable these examples are as oneTBB benchmarks, or some additional stabilization is required to achieve some KPI (e.g. 5% max).

Resolves: #1656 (part of)

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [x] updated in README.md
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@anchita20
@mehulBhandari20

### Other information
`class measurements` introduced with #1446 is moved to its own header file to make its use easier deep in example applications without conflicts with other utility classes.

Intel OSS Hackathon 2025