### PR TITLE
Automated Relative Error Report Generation for Range of Iterations

### DIFF
--- a/examples/parallel_reduce/convex_hull/convex_hull.hpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull.hpp
@@ -40,6 +40,7 @@
 namespace cfg {
 // convex hull problem user set parameters
 long numberOfPoints = 5000000; // problem size
+// long numberOfIterations = 100;
 
 // convex hull grain sizes for 3 subproblems. Be sure 16*GS < 512Kb
 const std::size_t generateGrainSize = 25000;
@@ -51,6 +52,7 @@ namespace util {
 bool silent = false;
 bool verbose = false;
 std::vector<std::string> OUTPUT;
+int numberOfIterations = 0;
 
 // utility functionality
 void ParseInputArgs(int argc, char* argv[], utility::thread_number_range& threads) {
@@ -61,6 +63,9 @@ void ParseInputArgs(int argc, char* argv[], utility::thread_number_range& thread
             //"-h" option for displaying help is present implicitly
             .positional_arg(threads, "n-of-threads", utility::thread_number_range_desc)
             .positional_arg(cfg::numberOfPoints, "n-of-points", "number of points")
+            .positional_arg(numberOfIterations,
+                            "n-of-iterations",
+                            "number of iterations the example runs internally")
             .arg(silent, "silent", "no output except elapsed time")
             .arg(verbose, "verbose", "turns verbose ON"));
     //disabling verbose if silent is specified
@@ -131,7 +136,7 @@ template <typename Index>
 struct edge {
     Index start;
     Index end;
-    edge(Index _p1, Index _p2) : start(_p1), end(_p2){};
+    edge(Index _p1, Index _p2) : start(_p1), end(_p2) {};
 };
 
 template <typename T>

--- a/examples/parallel_reduce/convex_hull/convex_hull.hpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull.hpp
@@ -40,7 +40,6 @@
 namespace cfg {
 // convex hull problem user set parameters
 long numberOfPoints = 5000000; // problem size
-// long numberOfIterations = 100;
 
 // convex hull grain sizes for 3 subproblems. Be sure 16*GS < 512Kb
 const std::size_t generateGrainSize = 25000;

--- a/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
@@ -30,9 +30,6 @@
 #include "oneapi/tbb/concurrent_vector.h"
 
 #include "convex_hull.hpp"
-#include <thread>
-
-// extern int numberOfIterations;
 
 typedef util::point<double> point_t;
 typedef oneapi::tbb::concurrent_vector<point_t> pointVec_t;

--- a/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
@@ -289,14 +289,12 @@ int main(int argc, char *argv[]) {
     points.reserve(cfg::numberOfPoints);
 
     if (!util::silent) {
-        std::cout << "Starting TBB-buffered version of QUICK HULL algorithm"
-                  << "\n";
+        std::cout << "Starting TBB-buffered version of QUICK HULL algorithm" << "\n";
     }
 
     if (util::numberOfIterations <= 0) {
         util::numberOfIterations = 10;
-        std::cout << "Setting the number of iterations = 10 default"
-                  << "\n";
+        std::cout << "Setting the number of iterations = 10 default" << "\n";
     }
     else {
         std::cout << "Input for the number of iterations = " << util::numberOfIterations << "\n";

--- a/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
@@ -241,12 +241,6 @@ void divide_and_conquer(const pointVec_t &P, pointVec_t &H, point_t p1, point_t 
         divide_and_conquer(P_reduced, H1, p1, p_far);
         divide_and_conquer(P_reduced, H2, p_far, p2);
 
-        // std::thread t1(divide_and_conquer, std::ref(P_reduced), std::ref(H1), p1, p_far);
-        // std::thread t2(divide_and_conquer, std::ref(P_reduced), std::ref(H2), p_far, p2);
-
-        // t1.join();
-        // t2.join();
-
         appendVector(H1, H);
         appendVector(H2, H);
     }
@@ -263,14 +257,8 @@ void quickhull(const pointVec_t &points, pointVec_t &hull) {
 
     pointVec_t H;
 
-    // divide_and_conquer(points, hull, p_maxx, p_minx);
-    // divide_and_conquer(points, H, p_minx, p_maxx);
-
-    std::thread t1(divide_and_conquer, std::ref(points), std::ref(hull), p_maxx, p_minx);
-    std::thread t2(divide_and_conquer, std::ref(points), std::ref(H), p_minx, p_maxx);
-
-    t1.join();
-    t2.join();
+    divide_and_conquer(points, hull, p_maxx, p_minx);
+    divide_and_conquer(points, H, p_minx, p_maxx);
 
     appendVector(H, hull);
 }

--- a/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
+++ b/examples/parallel_reduce/convex_hull/convex_hull_sample.cpp
@@ -279,7 +279,8 @@ int main(int argc, char *argv[]) {
 
     if (util::numberOfIterations <= 0) {
         util::numberOfIterations = 10;
-        std::cout << "Setting the number of iterations = 10 default" << "\n";
+        std::cout << "Setting the number of iterations = " << util::numberOfIterations
+                  << " default\n";
     }
     else {
         std::cout << "Input for the number of iterations = " << util::numberOfIterations << "\n";

--- a/generate_report.sh
+++ b/generate_report.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+BUILD_DIR=$(find build -maxdepth 1 -type d -name "gnu_*" | head -n 1)
+if [[ -z "$BUILD_DIR" ]]; then
+    echo "Error: No gnu_* directory found inside build/"
+    exit 1
+fi
+
+# Define the executable and output file
+EXE_NAME=$1
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+OUTPUT_FILE="${BUILD_DIR}/${EXE_NAME}_execution_report_${TIMESTAMP}.txt" #Output files in build/gnu_*/
+
+# List of n-of-iterations values to test
+ITERATIONS=(10 20 30 40 50 100 200 300 500) 
+
+# Clear previous report
+# rm -rf $OUTPUT_FILE
+rm -rf ${BUILD_DIR}/${EXE_NAME}_iterations_*.txt
+
+echo "EXAMPLE Name | Number of Iterations | Relative_Err" > $OUTPUT_FILE
+echo "--------------------------------------------------" >> $OUTPUT_FILE
+
+# Loop through each iteration value
+for n in "${ITERATIONS[@]}"; do
+    echo "Running $EXE_NAME with n-of-iterations=$n"
+
+    TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+   
+    LOG_FILE="${BUILD_DIR}/${EXE_NAME}_iterations_${n}_${TIMESTAMP}.txt" 
+
+    # Run the executable and capture output
+    OUTPUT=$(${BUILD_DIR}/$EXE_NAME n-of-iterations=$n)
+
+    wait
+   
+
+    # Extract Relative_Err (modify grep or awk based on actual output format)
+    REL_ERR=$(echo "$OUTPUT" | grep "Relative_Err" | awk -F': ' '{print $2}' | tr -d ' %')
+
+    echo "$REL_ERROR" 
+
+    echo "$OUTPUT" > "$LOG_FILE"
+
+    # Append to the report
+    echo "$EXE_NAME | $n | $REL_ERR" >> $OUTPUT_FILE
+done
+
+echo "Report generated: $OUTPUT_FILE"
+


### PR DESCRIPTION
### Description 
A new script added which can be run with arguments as binary name and it will generate report for sample list of iterations hard coded in script. It can be enhanced to pass iteration list at CMD line with other attributes required for exe execution.

Example:
 ./generate_report.sh convex_hull_sample

This will execute convex_hull_sample test case from build/gnu_* folder and will generate reports. Reports will be one for entire execution keeping information about relative error measurement in each iteration executions. Also, it will have log files for each iteration for any analysis.
It will clean log files before running new set of executions but will keep report file.

Fixes # - https://github.com/uxlfoundation/oneTBB/issues/1653

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [X] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
