### PR TITLE
examples:  build targets for benchmarking 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ This directory contains example usages of oneAPI Threading Building Blocks.
 Refer to the [System Requirements](https://github.com/uxlfoundation/oneTBB/blob/master/SYSTEM_REQUIREMENTS.md) for the list of supported hardware and software.
 
 ### Graphical User Interface (GUI)
-Some examples (e.g., fractal, seismic, tachyon, polygon_overlay) support different GUI modes, which may be defined via the `EXAMPLES_UI_MODE` CMake variable. 
+Some examples (e.g., fractal, seismic, tachyon, polygon_overlay) support different GUI modes, which may be defined via the `EXAMPLES_UI_MODE` CMake variable.
 Supported values are:
 - Cross-platform:
     - `con` - Console mode (Default).
@@ -40,3 +40,6 @@ Supported values are:
     - `x` - `X11` based implementation. Also `libXext` may be required to display the output correctly.
 - macOS*:
     - `mac` - `OpenGL` based implementation. Also requires the `Foundation` and `Cocoa` libraries availability.
+
+### Benchmark reports
+Some examples (e.g. tachyon, primes, sudoku) can be used for benchmarking purposes having special build targets (with `_data` suffix) to parse console output on execution and compose a .csv report file. This feature requires [gawk](https://www.gnu.org/software/gawk/) utility installed.

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -56,7 +56,7 @@ add_executable(
     src/ui.cpp
     src/util.cpp
     src/vector.cpp
-    src/vol.cpp 
+    src/vol.cpp
 )
 
 add_subdirectory(../../common/gui gui)
@@ -72,7 +72,11 @@ set(EXECUTABLE "$<TARGET_FILE:tachyon>")
 set(ARGS ${CMAKE_CURRENT_SOURCE_DIR}/dat/balls.dat)
 set(PERF_ARGS silent ${CMAKE_CURRENT_SOURCE_DIR}/dat/balls3.dat)
 set(LIGHT_ARGS ${CMAKE_CURRENT_SOURCE_DIR}/dat/model2.dat)
+set(BENCHMARK_ARGS no-bounding n-of-repeats=10 ${CMAKE_CURRENT_SOURCE_DIR}/dat/balls3.dat)
 
 add_execution_target(run_tachyon tachyon ${EXECUTABLE} "${ARGS}")
 add_execution_target(perf_run_tachyon tachyon ${EXECUTABLE} "${PERF_ARGS}")
 add_execution_target(light_test_tachyon tachyon ${EXECUTABLE} "${LIGHT_ARGS}")
+
+add_execution_target(benchmark_tachyon tachyon ${EXECUTABLE} "${BENCHMARK_ARGS}")
+add_benchmark_target(benchmark_tachyon_data tachyon ${EXECUTABLE} "${BENCHMARK_ARGS}")

--- a/examples/parallel_for/tachyon/README.md
+++ b/examples/parallel_for/tachyon/README.md
@@ -21,8 +21,10 @@ cmake --build .
 ## Running the sample
 ### Predefined make targets
 * `make run_tachyon` - executes the example with predefined parameters.
-* `make perf_run_tachyon` ` - executes the example with suggested parameters to measure the oneTBB performance.
+* `make perf_run_tachyon` - executes the example with suggested parameters to measure the oneTBB performance once.
 * `make light_test_tachyon` - executes the example with suggested parameters to reduce execution time.
+* `make benchmark_tachyon` - executes the example with suggested parameters to repeat performance measurements several times and report their relative error.
+* `make benchmark_tachyon_data` - same as `benchmark_tachyon` saving results into `benchmark_tachyon_data.csv` file.
 
 ### Application parameters
 Usage:

--- a/examples/parallel_for/tachyon/benchmark_tachyon_data.awk
+++ b/examples/parallel_for/tachyon/benchmark_tachyon_data.awk
@@ -1,0 +1,16 @@
+BEGIN {
+        print "infile,repetitions,avg_duration,rel_error"
+        summ=0;
+        cnt=0;
+}
+
+match($0, /tachyon.*n-of-repeats=([0-9]+) (.+): ([.0-9]+) seconds/, arr)  {
+  curr_rep = arr[1];
+  curr_file = arr[2];
+  summ += arr[3];
+  cnt++
+}
+
+/Relative_Err/ {
+  print curr_file "," curr_rep "," summ/cnt "," $3
+}

--- a/examples/parallel_reduce/primes/CMakeLists.txt
+++ b/examples/parallel_reduce/primes/CMakeLists.txt
@@ -28,6 +28,10 @@ target_compile_options(primes PRIVATE ${TBB_CXX_STD_FLAG})
 set(EXECUTABLE "$<TARGET_FILE:primes>")
 set(ARGS "")
 set(PERF_ARGS silent auto 1000000000 1000 20)
+set(BENCHMARK_ARGS n-of-repeats=3 number=10000000000)
 
 add_execution_target(run_primes primes ${EXECUTABLE} "${ARGS}")
 add_execution_target(perf_run_primes primes ${EXECUTABLE} "${PERF_ARGS}")
+
+add_execution_target(benchmark_primes primes ${EXECUTABLE} "${BENCHMARK_ARGS}")
+add_benchmark_target(benchmark_primes_data primes ${EXECUTABLE} "${BENCHMARK_ARGS}")

--- a/examples/parallel_reduce/primes/README.md
+++ b/examples/parallel_reduce/primes/README.md
@@ -11,6 +11,9 @@ cmake --build .
 ### Predefined make targets
 * `make run_primes` - executes the example with predefined parameters
 * `make perf_run_primes` - executes the example with suggested parameters to measure the oneTBB performance
+* `make benchmark_primes` - executes the example with suggested parameters to repeat performance measurements several times
+and report their relative error.
+* `make benchmark_primes_data` - same as `benchmark_primes` saving results into `benchmark_primes_data.csv` file.
 
 ### Application parameters
 Usage:

--- a/examples/parallel_reduce/primes/benchmark_primes_data.awk
+++ b/examples/parallel_reduce/primes/benchmark_primes_data.awk
@@ -1,0 +1,15 @@
+BEGIN {
+        print "range,repetitions,parallelism,avg_duration,rel_error"
+}
+
+match($0, /^#primes from \[([.0-9]+)\] .*\(([.0-9]+) sec with (.+) /, arr) {
+  t_id=arr[3];
+  range[t_id] = arr[1]
+  thread_sum[t_id] += arr[2];
+  thread_cnt[t_id] = thread_cnt[t_id] + 1
+}
+
+match($0, /(.+) (.+) Relative_Err : ([.0-9]+) %/, arr) {
+  t_id=arr[1];
+  print range[t_id] "," thread_cnt[t_id] "," t_id "," thread_sum[t_id]/(thread_cnt[t_id]) "," arr[3];
+}

--- a/examples/task_group/sudoku/CMakeLists.txt
+++ b/examples/task_group/sudoku/CMakeLists.txt
@@ -32,6 +32,10 @@ endif()
 set(EXECUTABLE "$<TARGET_FILE:sudoku>")
 set(ARGS 4 ${CMAKE_CURRENT_SOURCE_DIR}/input1 verbose)
 set(PERF_ARGS auto ${CMAKE_CURRENT_SOURCE_DIR}/input1 silent)
+set(BENCHMARK_ARGS filename=${CMAKE_CURRENT_SOURCE_DIR}/input4 n-of-repeats=3)
 
 add_execution_target(run_sudoku sudoku ${EXECUTABLE} "${ARGS}")
 add_execution_target(perf_run_sudoku sudoku ${EXECUTABLE} "${PERF_ARGS}")
+
+add_execution_target(benchmark_sudoku sudoku ${EXECUTABLE} "${BENCHMARK_ARGS}")
+add_benchmark_target(benchmark_sudoku_data sudoku ${EXECUTABLE} "${BENCHMARK_ARGS}")

--- a/examples/task_group/sudoku/README.md
+++ b/examples/task_group/sudoku/README.md
@@ -13,6 +13,8 @@ cmake --build .
 ### Predefined make targets
 * `make run_sudoku` - executes the example with predefined parameters.
 * `make perf_run_sudoku` - executes the example with suggested parameters to measure the oneTBB performance.
+* `make benchmark_sudoku` - executes the example with suggested parameters to repeat performance measurements several times and report their relative error.
+* `make benchmark_sudoku_data` - same as `benchmark_sudoku` saving results into `benchmark_sudoku_data.csv` file.
 
 ### Application parameters
 Usage:

--- a/examples/task_group/sudoku/benchmark_sudoku_data.awk
+++ b/examples/task_group/sudoku/benchmark_sudoku_data.awk
@@ -1,0 +1,16 @@
+BEGIN {
+        print "infile,repetitions,threads,avg_duration,rel_error"
+        match(run_args, /filename=(.+)[ ;]/, run_args_);
+        curr_file = run_args_[1]
+}
+
+match($0, /(Sudoku: Time to find .* on )([0-9]+)( threads: )([.0-9]+) seconds./, arr) {
+  t_id=arr[2];
+  thread_sum[t_id] += arr[4];
+  thread_cnt[t_id] = thread_cnt[t_id] + 1
+}
+
+match($0, /(Sudoku: Time to find.* on )([0-9]+)( threads[:]* Relative_Err : )([.0-9]+) %/, arr) {
+  t_id=arr[2];
+  print curr_file "," thread_cnt[t_id] "," t_id "," thread_sum[t_id]/(thread_cnt[t_id]) "," arr[4];
+}


### PR DESCRIPTION
### Description 

Add two new build targets to `Tachyon`, `Primes`, and `Sudoku` examples to execute them for benchmarking purposes with parameters obtained from experiments on 3 different platforms. 
Ideally, these parameters should allow to run the benchmarks in reasonable time with relative error 5% maximum.
The results can be optionally post-processed into .csv files to ease further analysis.

Resolves: #1656 (part of)

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [x] updated in README.md files
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Other information
follow up for #1669