### PR TITLE
POC implementation for task_group dynamic dependencies - part 1 - task_tracker

### DIFF
--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -108,6 +108,10 @@ inline void enqueue_impl(task_handle&& th, d1::task_arena_base* ta) {
 
     auto& ctx = task_handle_accessor::ctx_of(th);
 
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+    task_handle_accessor::mark_task_submitted(th);
+#endif
+
     // Do not access th after release
     r1::enqueue(*task_handle_accessor::release(th), ctx, ta);
 }

--- a/include/oneapi/tbb/task_group.h
+++ b/include/oneapi/tbb/task_group.h
@@ -88,8 +88,7 @@ private:
         __TBB_ASSERT(ed.context == &this->ctx(), "The task group context should be used for all tasks");
         task* res = task_ptr_or_nullptr(m_func);
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
-        task_dynamic_state* state = this->get_dynamic_state_if_created();
-        if (state) state->complete_task();
+        this->get_dynamic_state()->complete_task();
 #endif
         finalize(&ed);
         return res;
@@ -444,7 +443,13 @@ class isolated_task_group;
 #endif
 
 template <typename F>
-class function_stack_task : public d1::task {
+class function_stack_task
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+    : public task_with_dynamic_state
+#else
+    : public d1::task
+#endif
+{
     const F& m_func;
     d1::wait_tree_vertex_interface* m_wait_tree_vertex;
 
@@ -453,6 +458,9 @@ class function_stack_task : public d1::task {
     }
     task* execute(d1::execution_data&) override {
         task* res = d2::task_ptr_or_nullptr(m_func);
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+        this->get_dynamic_state()->complete_task();
+#endif
         finalize();
         return res;
     }

--- a/include/oneapi/tbb/task_group.h
+++ b/include/oneapi/tbb/task_group.h
@@ -87,6 +87,10 @@ private:
     d1::task* execute(d1::execution_data& ed) override {
         __TBB_ASSERT(ed.context == &this->ctx(), "The task group context should be used for all tasks");
         task* res = task_ptr_or_nullptr(m_func);
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+        task_dynamic_state* state = this->get_dynamic_state_if_created();
+        if (state) state->complete_task();
+#endif
         finalize(&ed);
         return res;
     }
@@ -487,6 +491,9 @@ protected:
 
         using acs = d2::task_handle_accessor;
         __TBB_ASSERT(&acs::ctx_of(h) == &context(), "Attempt to schedule task_handle into different task_group");
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+        acs::mark_task_submitted(h);
+#endif
 
         bool cancellation_status = false;
         try_call([&] {
@@ -580,6 +587,9 @@ public:
 
         using acs = d2::task_handle_accessor;
         __TBB_ASSERT(&acs::ctx_of(h) == &context(), "Attempt to schedule task_handle into different task_group");
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+        acs::mark_task_submitted(h);
+#endif
 
         d1::spawn(*acs::release(h), context());
     }
@@ -701,6 +711,9 @@ using detail::d1::is_current_task_group_canceling;
 using detail::r1::missing_wait;
 
 using detail::d2::task_handle;
+#if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+using detail::d2::task_tracker;
+#endif
 }
 
 } // namespace tbb

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1321,6 +1321,11 @@ TEST_CASE("test task_tracker") {
 
         tg.run_and_wait(std::move(task4_handle));
         CHECK_MESSAGE(task_placeholder == 4, "Task body was not executed");
+
+        tbb::task_handle empty_handle;
+        CHECK(task3_tracker2);
+        task3_tracker2 = empty_handle;
+        CHECK_MESSAGE(!task3_tracker2, "Non-empty task_tracker after move assignment from empty handle");
     }
     {
         // Test submission through enqueue
@@ -1337,7 +1342,6 @@ TEST_CASE("test task_tracker") {
             CHECK_MESSAGE(enqueue_task_tracker.is_completed(), "Unexpected result for is_completed for enqueue task");
             CHECK_MESSAGE(task_placeholder == 5, "Task body was not executed");
         }
-
         {
             tbb::task_tracker enqueue_task_tracker;
             arena.execute([&] {


### PR DESCRIPTION
### Description 
First part of POC implementation for task_group dynamic dependencies. 
Design described in the RFC #1664
This PR extends the `task_group` tasks with the dynamic state, that currently allows tracking the progress of the task using the new object `task_tracker`.
In the future parts, dynamic state of the task would be reused for setting and transferring dependencies between tasks.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
