### PR TITLE
POC implementation for task_group dynamic dependencies - part 2 - make_edge

### DIFF
--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -214,6 +214,7 @@ public:
     }
 private:
     wait_tree_vertex_interface* my_parent;
+protected:
     std::atomic<std::uint64_t> m_ref_count;
 };
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -35,6 +35,10 @@ class task_handle;
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
 
 class task_with_dynamic_state;
+class task_handle_task;
+class successor_vertex;
+
+inline task_with_dynamic_state* release_successors_list(successor_vertex* list);
 class task_dynamic_state {
     enum class task_status {
         no_status = 0,
@@ -42,8 +46,11 @@ class task_dynamic_state {
         completed = 2
     };
 public:
-    task_dynamic_state(d1::small_object_allocator& alloc)
-        : m_task_status(task_status::no_status)
+    task_dynamic_state(task_with_dynamic_state* task, d1::small_object_allocator& alloc)
+        : m_task(task)
+        , m_task_status(task_status::no_status)
+        , m_successors_list_head(nullptr)
+        , m_continuation_vertex(nullptr)
         , m_num_references(0)
         , m_allocator(alloc)
     {}
@@ -60,8 +67,15 @@ public:
         m_task_status.store(task_status::submitted, std::memory_order_release);
     }
 
-    void complete_task() {
+    task_with_dynamic_state* complete_task() {
         m_task_status.store(task_status::completed, std::memory_order_release);   
+
+        task_with_dynamic_state* next_task = release_successors_list(m_successors_list_head.exchange(nullptr));
+
+        // Releasing the task ownership of the dynamic_state
+        release();
+
+        return next_task;
     }
 
     bool was_submitted() const {
@@ -71,11 +85,50 @@ public:
     bool is_completed() const {
         return m_task_status.load(std::memory_order_acquire) == task_status::completed;
     }
+
+    bool has_dependencies() const {
+        return m_continuation_vertex.load(std::memory_order_acquire) != nullptr;
+    }
+    
+    void unset_dependency() {
+        m_continuation_vertex.store(nullptr, std::memory_order_release);
+    }
+
+    void add_successor(successor_vertex* successor);
+    void release_continuation();
+    
+    successor_vertex* get_continuation_vertex() {
+        successor_vertex* current_continuation_vertex = m_continuation_vertex.load(std::memory_order_acquire);
+
+        if (current_continuation_vertex == nullptr) {
+            d1::small_object_allocator alloc;
+            successor_vertex* new_continuation_vertex = alloc.new_object<successor_vertex>(m_task, alloc);
+
+            if (!m_continuation_vertex.compare_exchange_strong(current_continuation_vertex, new_continuation_vertex)) {
+                // Other thread already created a continuation vertex
+                alloc.delete_object(new_continuation_vertex);
+            } else {
+                // This thread has updated the continuation vertex
+                current_continuation_vertex = new_continuation_vertex;
+            }
+        }
+        __TBB_ASSERT(current_continuation_vertex != nullptr, "Failed to get continuation vertex");
+        return current_continuation_vertex;
+    }
+
 private:
+    task_with_dynamic_state* m_task;
     std::atomic<task_status> m_task_status;
+    std::atomic<successor_vertex*> m_successors_list_head;
+    std::atomic<successor_vertex*> m_continuation_vertex;
     std::atomic<std::size_t> m_num_references;
     d1::small_object_allocator m_allocator;
 };
+
+inline void internal_make_edge(task_dynamic_state* pred, task_dynamic_state* succ) {
+    __TBB_ASSERT(pred != nullptr && succ != nullptr , nullptr);
+    pred->add_successor(succ->get_continuation_vertex());
+}
 
 class task_with_dynamic_state : public d1::task {
 public:
@@ -86,7 +139,7 @@ public:
 
     task_dynamic_state* get_dynamic_state() {
         if (m_state == nullptr) {
-            m_state = m_allocator.new_object<task_dynamic_state>(m_allocator);
+            m_state = m_allocator.new_object<task_dynamic_state>(this, m_allocator);
         }
         return m_state;
     }
@@ -98,6 +151,44 @@ private:
     task_dynamic_state* m_state;
     d1::small_object_allocator& m_allocator;
 };
+
+class successor_vertex : public d1::reference_vertex {
+public:
+    successor_vertex(task_with_dynamic_state* task, d1::small_object_allocator& alloc)
+        // Reserving 1 for task_handle that owns the task for which the predecessors are added
+        // reference counter would be released when this task_handle would be submitted for execution
+        : d1::reference_vertex(nullptr, 1)
+        , m_task(task)
+        , m_next_successor(nullptr)
+        , m_allocator(alloc)
+    {}
+
+    task_with_dynamic_state* release_bypass(std::uint32_t delta = 1) {
+        task_with_dynamic_state* next_task = nullptr;
+
+        std::uint32_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<uint64_t>(delta);
+
+        if (ref == 0) {
+            // TODO: can we skip this step since the task would be spawned anyway
+            m_task->get_dynamic_state()->unset_dependency();
+            next_task = m_task;
+            m_allocator.delete_object(this);
+        }
+        return next_task;
+    }
+
+    void set_next_successor(successor_vertex* next) {
+        m_next_successor = next;
+    }
+
+    successor_vertex* get_next_successor() const {
+        return m_next_successor;
+    }
+private:
+    task_with_dynamic_state* m_task;
+    successor_vertex* m_next_successor;
+    d1::small_object_allocator m_allocator;
+}; // class successor_vertex
 #endif // __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
 
 class task_handle_task
@@ -140,14 +231,13 @@ public:
     d1::task_group_context& ctx() const { return m_ctx; }
 };
 
-
 class task_handle {
     struct task_handle_task_finalizer_t{
         void operator()(task_handle_task* p){
-            p->finalize();
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
-
+            p->get_dynamic_state()->release();
 #endif
+            p->finalize();
         }
     };
     using handle_impl_t = std::unique_ptr<task_handle_task, task_handle_task_finalizer_t>;
@@ -174,8 +264,7 @@ private:
 
     task_handle(task_handle_task* t) : m_handle {t} {
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
-        task_dynamic_state* state = m_handle->get_dynamic_state();
-        state->reserve();
+        m_handle->get_dynamic_state()->reserve();
 #endif
     }
 
@@ -197,8 +286,25 @@ struct task_handle_accessor {
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
     static void mark_task_submitted(task_handle& th) {
         __TBB_ASSERT(th.m_handle, "mark_task_submitted does not expect empty task_handle");
-        task_dynamic_state* state = th.m_handle->get_dynamic_state_if_created();
-        if (state) state->mark_submitted();
+        task_dynamic_state* state = get_task_dynamic_state(th);
+        if (state != nullptr) state->mark_submitted();
+    }
+
+    static task_dynamic_state* get_task_dynamic_state(task_handle& th) {
+        return th.m_handle->get_dynamic_state_if_created();
+    }
+
+    static void release_continuation(task_handle& th) {
+        __TBB_ASSERT(th.m_handle, "release_continuation does not expect empty task_handle");
+        task_dynamic_state* state = get_task_dynamic_state(th);
+        __TBB_ASSERT(state != nullptr, "dynamic state was not created for task with dependencies");
+        state->release_continuation();
+    }
+
+    static bool has_dependencies(task_handle& th) {
+        __TBB_ASSERT(th.m_handle, "has_dependency does not expect empty task_handle");
+        task_dynamic_state* state = get_task_dynamic_state(th);
+        return state != nullptr ? state->has_dependencies() : false;
     }
 #endif
 };
@@ -219,6 +325,62 @@ inline bool operator!=(std::nullptr_t, task_handle const& th) noexcept {
 }
 
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
+inline task_with_dynamic_state* release_successors_list(successor_vertex* successor) {
+    task_with_dynamic_state* next_task = nullptr;
+
+    while (successor != nullptr) {
+        successor_vertex* next_successor = successor->get_next_successor();
+        task_with_dynamic_state* successor_task = successor->release_bypass();
+
+        if (successor_task != nullptr) {
+            if (next_task == nullptr) {
+                next_task = successor_task;
+            } else {
+                // Successor task is guaranteed to be task_handle_task
+                // safe to perform static_cast
+                d1::spawn(*successor_task, static_cast<task_handle_task*>(successor_task)->ctx());
+            }
+        }
+        successor = next_successor;
+    }
+    return next_task;
+}
+
+inline void task_dynamic_state::add_successor(successor_vertex* successor) {
+    __TBB_ASSERT(successor != nullptr, nullptr);
+
+    if (!is_completed()) {
+        successor->reserve();
+
+        successor_vertex* current_successors_list_head = m_successors_list_head.load(std::memory_order_acquire);
+        successor->set_next_successor(current_successors_list_head);
+
+        while (!m_successors_list_head.compare_exchange_strong(current_successors_list_head, successor)) {
+            // Other thread updated the head of the list
+            if (is_completed()) {
+                // Current task has completed while we tried to insert the successor to the list
+                successor->release();
+                break;
+            }
+            successor->set_next_successor(current_successors_list_head);
+        }
+    }
+    // TODO: test single predecessor in completed state
+}
+
+inline void task_dynamic_state::release_continuation() {
+    successor_vertex* current_vertex = m_continuation_vertex.load(std::memory_order_acquire);
+    __TBB_ASSERT(current_vertex != nullptr, "release_continuation requested for task without dependencies");
+    task_with_dynamic_state* task = current_vertex->release_bypass();
+    
+    // Dependent tasks have completed before the task_handle holding the continuation was submitted for execution
+    // task_handle was the last owner of the taskand it should be spawned
+    if (task != nullptr) {
+        // successor task is guaranteed to be task_handle_task, safe to use static_cast
+        d1::spawn(*task, static_cast<task_handle_task*>(task)->ctx());
+    }
+}
+
 class task_tracker {
 public:
     task_tracker() : m_task_state(nullptr) {}
@@ -322,7 +484,15 @@ private:
     }
 #endif // !__TBB_CPP20_COMPARISONS_PRESENT
 
+    friend struct task_tracker_accessor;
+
     task_dynamic_state* m_task_state;
+};
+
+struct task_tracker_accessor {
+    static task_dynamic_state* get_task_dynamic_state(task_tracker& tracker) {
+        return tracker.m_task_state;
+    }
 };
 #endif
 

--- a/include/oneapi/tbb/detail/_task_handle.h
+++ b/include/oneapi/tbb/detail/_task_handle.h
@@ -68,6 +68,7 @@ private:
 };
 
 inline task_with_dynamic_state* release_successors_list(successors_list_node* list);
+
 class task_dynamic_state {
     enum class task_status {
         no_status = 0,
@@ -310,15 +311,12 @@ struct task_handle_accessor {
 
     static void release_continuation(task_handle& th) {
         __TBB_ASSERT(th.m_handle, "release_continuation does not expect empty task_handle");
-        task_dynamic_state* state = get_task_dynamic_state(th);
-        __TBB_ASSERT(state != nullptr, "dynamic state was not created for task with dependencies");
-        state->release_continuation();
+        th.m_handle->get_dynamic_state()->release_continuation();
     }
 
     static bool has_dependencies(task_handle& th) {
         __TBB_ASSERT(th.m_handle, "has_dependency does not expect empty task_handle");
-        task_dynamic_state* state = get_task_dynamic_state(th);
-        return state != nullptr ? state->has_dependencies() : false;
+        return th.m_handle->get_dynamic_state()->has_dependencies();
     }
 #endif
 };

--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -110,10 +110,16 @@ inline void enqueue_impl(task_handle&& th, d1::task_arena_base* ta) {
 
 #if __TBB_PREVIEW_TASK_GROUP_EXTENSIONS
     task_handle_accessor::mark_task_submitted(th);
-#endif
 
-    // Do not access th after release
-    r1::enqueue(*task_handle_accessor::release(th), ctx, ta);
+    if (task_handle_accessor::has_dependencies(th)) {
+        task_handle_accessor::release_continuation(th);
+        task_handle_accessor::release(th);
+    } else 
+#endif
+    {
+        // Do not access th after release
+        r1::enqueue(*task_handle_accessor::release(th), ctx, ta);
+    }
 }
 } //namespace d2
 

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1462,7 +1462,7 @@ void test_not_submitted_predecessors() {
 template <submit_function SubmitFunction, bool AlwaysCompleted>
 void test_submitted_predecessors() {
     tbb::task_arena arena;
-    const std::size_t num_predecessors = 1000;
+    const std::size_t num_predecessors = 500;
     tbb::task_group tg;
     std::atomic<std::size_t> task_placeholder{0};
 

--- a/test/tbb/test_task_group.cpp
+++ b/test/tbb/test_task_group.cpp
@@ -1462,7 +1462,7 @@ void test_not_submitted_predecessors() {
 template <submit_function SubmitFunction, bool AlwaysCompleted>
 void test_submitted_predecessors() {
     tbb::task_arena arena;
-    const std::size_t num_predecessors = 100;
+    const std::size_t num_predecessors = 1000;
     tbb::task_group tg;
     std::atomic<std::size_t> task_placeholder{0};
 


### PR DESCRIPTION
### Description 
Second part of POC implementation for task_group dynamic dependencies. 
Design described in the RFC #1664 
First part is implemented in the PR #1682 

This PR extends the `task_group` API with the new method `make_edge` that allows to specify predecessor-successor dependency between two tasks. 
`task_dynamic_state` class was extended to contain current continuation vertex and the successors list. 


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
