### PR TITLE
Fix hardening flags on aarch64

### DIFF
--- a/cmake/compilers/Clang.cmake
+++ b/cmake/compilers/Clang.cmake
@@ -65,7 +65,7 @@ endif()
 # Clang flags to prevent compiler from optimizing out security checks
 set(TBB_COMMON_COMPILE_FLAGS ${TBB_COMMON_COMPILE_FLAGS} -Wformat -Wformat-security -Werror=format-security -fPIC $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fstack-protector-strong>)
 
-if (NOT APPLE AND NOT ANDROID_PLATFORM)
+if (NOT APPLE AND NOT ANDROID_PLATFORM AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
     set(TBB_LIB_COMPILE_FLAGS ${TBB_LIB_COMPILE_FLAGS} -fstack-clash-protection $<$<NOT:$<BOOL:${EMSCRIPTEN}>>:-fcf-protection=full>)
 endif()
 


### PR DESCRIPTION
### Description 

This PR changes fcf-protection to only apply on x86_64. Please let me know if I should add a check for the ARM equivelent of `-mbranch-protection=standard`.

Fixes #1698 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
