### PR TITLE
repair 3 compilation errors

### DIFF
--- a/src/tbb/parallel_pipeline.cpp
+++ b/src/tbb/parallel_pipeline.cpp
@@ -70,7 +70,7 @@ private:
     friend class base_filter;
     friend void set_end_of_input(d1::base_filter& bf);
 
-    task_group_context& my_context;
+    d1::task_group_context& my_context;
 
     //! Pointer to first filter in the pipeline.
     d1::base_filter* first_filter;

--- a/src/tbb/parallel_pipeline.cpp
+++ b/src/tbb/parallel_pipeline.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbb/waiters.h
+++ b/src/tbb/waiters.h
@@ -71,7 +71,10 @@ public:
                         return true;
                     }
 
-                    if (!my_arena.my_thread_leave.is_retention_allowed() ||
+                    if (
+#if __TBB_PREVIEW_PARALLEL_PHASE
+                        !my_arena.my_thread_leave.is_retention_allowed() ||
+#endif
                         my_arena.my_threading_control->is_any_other_client_active())
                     {
                         break;

--- a/src/tbbmalloc/Customize.h
+++ b/src/tbbmalloc/Customize.h
@@ -94,7 +94,7 @@ namespace tbb {
 namespace detail {
 namespace d1 {
 
-    enum notify_type {prepare=0, cancel, acquired, releasing, destroy};
+    enum notify_type {prepare=0, cancel, acquired, releasing};
 
 #if TBB_USE_PROFILING_TOOLS
     inline void call_itt_notify(notify_type t, void *ptr) {

--- a/src/tbbmalloc/Customize.h
+++ b/src/tbbmalloc/Customize.h
@@ -94,7 +94,7 @@ namespace tbb {
 namespace detail {
 namespace d1 {
 
-    enum notify_type {prepare=0, cancel, acquired, releasing};
+    enum notify_type {prepare=0, cancel, acquired, releasing, destroy};
 
 #if TBB_USE_PROFILING_TOOLS
     inline void call_itt_notify(notify_type t, void *ptr) {

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/tbbmalloc/frontend.cpp
+++ b/src/tbbmalloc/frontend.cpp
@@ -2885,7 +2885,7 @@ void doThreadShutdownNotification(TLSData* tls, bool main_thread)
 }
 
 #if USE_PTHREAD
-void mallocThreadShutdownNotification(void* arg)
+extern "C" void mallocThreadShutdownNotification(void* arg)
 {
     // The routine is called for each pool (as TLS dtor) on each thread, except for the main thread
     if (!isMallocInitialized()) return;


### PR DESCRIPTION
Repair 3 compilation errors on clang++ (version==20.1) with tiny changes on code.

- src/tbb/parallel_pipeline.cpp
  ```text
  tbb/src/tbb/parallel_pipeline.cpp:42:9: error: non-const lvalue reference to type 'task_group_context' cannot bind to a value of unrelated type 'd1::task_group_context'
  ```
  It seems that clang++-20 wont ADL `task_group_context` into `d1::task_group_context`, so make it explicit.

- src/tbb/waiters.h
  ```text
  tbb/src/tbb/waiters.h:74:35: error: no member named 'my_thread_leave' in 'tbb::detail::r1::arena'
  ```
  The member variable is valid only if `__TBB_PREVIEW_PARALLEL_PHASE` is defined to `true`.

- src/tbbmalloc/frontend.cpp
  ```text
  tbb/src/tbb/dynamic_link.cpp:520:17: error: declaration of 'mallocThreadShutdownNotification' in module tbb follows declaration in the global module
  ```
  The previous one declared with `extern "C"` and causes ambiguous abi (espesially when compiled into a `C++20 module`.


Thank you! :)