### PR TITLE
Disable scalable memory pools from test_tbb_header when _CRTDBG_MAP_ALLOC is defined

### DIFF
--- a/test/tbb/test_tbb_header.cpp
+++ b/test/tbb/test_tbb_header.cpp
@@ -77,6 +77,14 @@
 #undef _DEBUG
 #endif /* !TBB_USE_DEBUG && defined(_DEBUG) */
 
+#if __TBB_TEST_SECONDARY && TBB_PREVIEW_MEMORY_POOL && defined(_CRTDBG_MAP_ALLOC)
+// when _CRTDBG_MAP_ALLOC is defined, the base versions of malloc, free and realloc are replaced with
+// their debug versions with different amount of arguments. It is implemented as #define malloc(x) _malloc_dbg(x, additional-args)
+// that breaks the definition of tbb::detail::d1::base_pool::malloc/free/realloc
+// excluding memory_pool.h from testing when this mode is enabled
+#undef TBB_PREVIEW_MEMORY_POOL
+#endif
+
 #include "tbb/tbb.h"
 
 #if !__TBB_TEST_SECONDARY
@@ -174,9 +182,11 @@ static void TestExceptionClassesExports () {
 static void TestPreviewNames() {
     TestTypeDefinitionPresence2( concurrent_lru_cache<int, int> );
     TestTypeDefinitionPresence( isolated_task_group );
+#if TBB_PREVIEW_MEMORY_POOL
     TestTypeDefinitionPresence( memory_pool_allocator<int> );
     TestTypeDefinitionPresence( memory_pool<std::allocator<int>> );
     TestTypeDefinitionPresence( fixed_pool );
+#endif
 }
 #endif
 


### PR DESCRIPTION
### Description 
[_CRTDBG_MAP_ALLOC](https://learn.microsoft.com/en-us/cpp/c-runtime-library/crtdbg-map-alloc?view=msvc-170) macro replaces the standard heap allocation functions such as `malloc`, `free` and `realloc`  with their debug analogues:

```cpp
// defined in <crtdbg.h> header
#define malloc(x) _malloc_dbg(x, more-args)
```

This breaks the definition of `malloc`, `free` and `realloc` member functions in TBB scalable memory pools.

Since currently only `test_tbb_header_secondary` tests _CRTDBG_MAP_ALLOC, we need to exclude scalable memory pools from this testing because of this issue.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
