### PR TITLE
Fix various issues with build on Windows

### DIFF
--- a/examples/common/cmake/common.cmake
+++ b/examples/common/cmake/common.cmake
@@ -50,7 +50,7 @@ endmacro()
 macro(add_benchmark_target TARGET_NAME TARGET_DEPENDENCIES EXECUTABLE ARGS)
     find_program(GAWK gawk NO_CACHE)
     if(NOT GAWK)
-      message(WARNING "AWK tool is not forund: no benchmark reports will be composed by ${TARGET_NAME}.")
+      message(WARNING "AWK tool is not found: no benchmark reports will be composed by ${TARGET_NAME}.")
     else()
       message("AWK tool to compose data reports by ${TARGET_NAME}: ${GAWK}")
       find_file(TARGET_NAME_FILTER

--- a/examples/common/utility/measurements.hpp
+++ b/examples/common/utility/measurements.hpp
@@ -53,10 +53,10 @@ public:
     double computeRelError() {
         // Accumulate the total duration in microseconds using std::accumulate with a lambda function
         assert(0 != _time_intervals.size());
-        auto total_duration = std::accumulate(
+        unsigned long long total_duration = std::accumulate(
             _time_intervals.begin(),
             _time_intervals.end(),
-            0, // Start with 0 count
+            0ull, // Start with 0 count
             [](long long total, const std::pair<time_point, time_point>& interval) {
                 // Compute the difference and add it to the total
                 return total + std::chrono::duration_cast<std::chrono::microseconds>(

--- a/examples/parallel_for/seismic/CMakeLists.txt
+++ b/examples/parallel_for/seismic/CMakeLists.txt
@@ -26,6 +26,9 @@ add_subdirectory(../../common/gui gui)
 
 target_link_libraries(seismic PUBLIC TBB::tbb Threads::Threads UI_LIB_seismic)
 target_compile_options(seismic PRIVATE ${TBB_CXX_STD_FLAG})
+if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
+    target_compile_options(seismic PRIVATE /EHsc)
+endif()
 
 if (EXAMPLES_UI_MODE STREQUAL "con")
     target_compile_definitions(seismic PRIVATE _CONSOLE)

--- a/examples/parallel_for/tachyon/CMakeLists.txt
+++ b/examples/parallel_for/tachyon/CMakeLists.txt
@@ -63,9 +63,12 @@ add_subdirectory(../../common/gui gui)
 
 target_link_libraries(tachyon TBB::tbb Threads::Threads UI_LIB_tachyon)
 target_compile_options(tachyon PRIVATE ${TBB_CXX_STD_FLAG})
-
-if (MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
+if (MSVC)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
     target_compile_options(tachyon PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+  else()
+    target_compile_options(tachyon PRIVATE /EHsc)
+  endif()
 endif()
 
 set(EXECUTABLE "$<TARGET_FILE:tachyon>")

--- a/examples/parallel_reduce/primes/CMakeLists.txt
+++ b/examples/parallel_reduce/primes/CMakeLists.txt
@@ -24,6 +24,9 @@ add_executable(primes main.cpp primes.cpp)
 
 target_link_libraries(primes TBB::tbb Threads::Threads)
 target_compile_options(primes PRIVATE ${TBB_CXX_STD_FLAG})
+if (MSVC AND NOT CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
+  target_compile_options(primes PRIVATE /EHsc)
+endif()
 
 set(EXECUTABLE "$<TARGET_FILE:primes>")
 set(ARGS "")

--- a/examples/task_group/sudoku/CMakeLists.txt
+++ b/examples/task_group/sudoku/CMakeLists.txt
@@ -24,9 +24,12 @@ add_executable(sudoku sudoku.cpp)
 
 target_link_libraries(sudoku TBB::tbb Threads::Threads)
 target_compile_options(sudoku PRIVATE ${TBB_CXX_STD_FLAG})
-
-if (MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
+if (MSVC)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL IntelLLVM)
     target_compile_options(sudoku PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+  else()
+    target_compile_options(sudoku PRIVATE /EHsc)
+  endif()
 endif()
 
 set(EXECUTABLE "$<TARGET_FILE:sudoku>")


### PR DESCRIPTION
This fixes:
* A typo: _AWK tool is not forund..._ => _AWK tool is not found: ..._
* Type conversion warning: _warning C4244: '=': conversion from '\_Rep' to '\_Ty', possible loss of data_, with `_Rep=__int64` and `_Ty=int`.
* A warning about usage of exception handling without stack unwinding code generation for primes, sudoku, tachyon and seismic examples: _examples\common\utility\utility.hpp(486,9): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc_
