### PR TITLE
Extend test dynamic link

### DIFF
--- a/include/oneapi/tbb/detail/_assert.h
+++ b/include/oneapi/tbb/detail/_assert.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2022 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_assert.h
+++ b/include/oneapi/tbb/detail/_assert.h
@@ -30,7 +30,8 @@ namespace r1 {
 /** Normally called from __TBB_ASSERT macro.
   If assertion handler is null, print message for assertion failure and abort.
   Otherwise call the assertion handler. */
-TBB_EXPORT void __TBB_EXPORTED_FUNC assertion_failure(const char* location, int line, const char* expression, const char* comment);
+TBB_EXPORT void __TBB_EXPORTED_FUNC assertion_failure(const char *location, int line,
+                                                      const char *expression, const char *comment);
 #if __TBBMALLOC_BUILD
 }} // namespaces rml::internal
 #else

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -160,7 +160,10 @@ namespace r1 {
                         DLERROR_SPECIFIER "\n", prefix, str, error);
             break;
         case dl_sym_not_found:     // char const * sym, dlerr_t err:
-            // TODO: Print not found symbol once it is used by the implementation
+            str = va_arg(args, const char*);
+            error = va_arg(args, dlerr_t);
+            TBB_FPRINTF(stderr, "%s The symbol \"%s\" was not resolved. System error: "
+                        DLERROR_SPECIFIER "\n", prefix, str, error);
             break;
         case dl_sys_fail:
             str = va_arg(args, const char*);
@@ -252,6 +255,7 @@ namespace r1 {
             dynamic_link_descriptor const & desc = descriptors[k];
             pointer_to_handler addr = (pointer_to_handler)dlsym( module, desc.name );
             if ( !addr ) {
+                DYNAMIC_LINK_WARNING( dl_sym_not_found, desc.name, dlerror() );
                 return false;
             }
             h[k] = addr;

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -507,6 +507,7 @@ namespace r1 {
         // RTLD_GLOBAL - to guarantee that old TBB will find the loaded library
         // RTLD_NOLOAD - not to load the library without the full path
         library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
+        fprintf(stdout, "global_symbols_link: library_handle = %p, for '%s'\n", library_handle, library);
 #endif /* _WIN32 */
         if (library_handle) {
             if (!resolve_symbols(library_handle, descriptors, required)) {

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -426,7 +426,7 @@ namespace r1 {
                     otherwise -- Ok, number of characters (incl. terminating null) written to buffer.
     */
     static std::size_t abs_path( char const * name, char * path, std::size_t len ) {
-        if ( ap_data._len == 0 )
+        if ( !name || ap_data._len == 0 )
             return 0;
 
         std::size_t name_len = std::strlen( name );

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -136,12 +136,17 @@ namespace r1 {
         const char* str = nullptr;
         // Note: dlerr_t depends on OS: it is char const * on Linux* and macOS*, int on Windows*.
 #if _WIN32
-        #define DLERROR_SPECIFIER "%d"
+#if __INTEL_LLVM_COMPILER
+// Suppress the incorrect warning about the format specifier for the unsigned long long type.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat"
+#endif
+        #define DLERROR_SPECIFIER "%ul"
         typedef DWORD dlerr_t;
 #else
         #define DLERROR_SPECIFIER "%s"
         typedef const char* dlerr_t;
-#endif
+#endif                          // _WIN32
         dlerr_t error = 0;
 
         std::va_list args;
@@ -216,6 +221,9 @@ namespace r1 {
         va_end(args);
     } // library_warning
 #undef DLERROR_SPECIFIER
+#if _WIN32 && __INTEL_LLVM_COMPILER
+#pragma GCC diagnostic pop
+#endif
 #else
     static void dynamic_link_warning( int code, ... ) {
         suppress_unused_warning(code);

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -507,7 +507,6 @@ namespace r1 {
         // RTLD_GLOBAL - to guarantee that old TBB will find the loaded library
         // RTLD_NOLOAD - not to load the library without the full path
         library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
-        fprintf(stdout, "global_symbols_link: library_handle = %p, for '%s'\n", library_handle, library);
 #endif /* _WIN32 */
         if (library_handle) {
             if (!resolve_symbols(library_handle, descriptors, required)) {

--- a/src/tbb/dynamic_link.cpp
+++ b/src/tbb/dynamic_link.cpp
@@ -235,6 +235,8 @@ namespace r1 {
 
 #elif defined(DYNAMIC_LINK_WARNING)
 #define __DYNAMIC_LINK_REPORT_SIGNATURE_ERRORS 1
+#else
+#define DYNAMIC_LINK_WARNING(...) (void)0
 #endif /* !defined(DYNAMIC_LINK_WARNING) && !__TBB_WIN8UI_SUPPORT && __TBB_DYNAMIC_LOAD_ENABLED */
 
     static bool resolve_symbols( dynamic_link_handle module, const dynamic_link_descriptor descriptors[], std::size_t required )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -428,9 +428,8 @@ if (TARGET TBB::tbb)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH_USE_ORIGIN TRUE)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$ORIGIN")
     target_compile_definitions(test_dynamic_link PRIVATE "TBBLIB_NAME=\"$<TARGET_FILE_NAME:TBB::tbb>\"")
-    # Making unsigned library so that the test fails to load it
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stub_unsigned_lib.cpp "void foo(){}")
-    add_library(stub_unsigned SHARED ${CMAKE_CURRENT_BINARY_DIR}/stub_unsigned_lib.cpp)
+    # Making unsigned library which the test fails loading
+    add_library(stub_unsigned SHARED ${CMAKE_CURRENT_SOURCE_DIR}/tbb/stub_unsigned_lib.cpp)
     add_dependencies(test_dynamic_link stub_unsigned)
 
     if (LINKER_HAS_NO_AS_NEEDED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -420,7 +420,15 @@ if (TARGET TBB::tbb)
     if (NOT TBB_TCM_TESTING)
         tbb_add_test(SUBDIR tbb NAME test_arena_priorities DEPENDENCIES TBB::tbb)
     endif()
-    tbb_add_test(SUBDIR tbb NAME test_dynamic_link DEPENDENCIES TBB::tbb)
+
+    tbb_add_test(SUBDIR tbb NAME test_dynamic_link)
+    add_dependencies(test_dynamic_link TBB::tbb)
+    target_include_directories(test_dynamic_link PRIVATE
+        $<TARGET_PROPERTY:TBB::tbb,INTERFACE_INCLUDE_DIRECTORIES>)
+    set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH_USE_ORIGIN TRUE)
+    set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$ORIGIN")
+    # set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:TBB::tbb>")
+
     if (LINKER_HAS_NO_AS_NEEDED)
         # The linker may not detect a dependency on pthread in static variable constructors.
         target_link_libraries(test_dynamic_link PRIVATE "-Wl,--no-as-needed")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -428,7 +428,10 @@ if (TARGET TBB::tbb)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH_USE_ORIGIN TRUE)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$ORIGIN")
     target_compile_definitions(test_dynamic_link PRIVATE "TBBLIB_NAME=\"$<TARGET_FILE_NAME:TBB::tbb>\"")
-    # set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:TBB::tbb>")
+    # Making unsigned library so that the test fails to load it
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/stub_unsigned_lib.cpp "void foo(){}")
+    add_library(stub_unsigned SHARED ${CMAKE_CURRENT_BINARY_DIR}/stub_unsigned_lib.cpp)
+    add_dependencies(test_dynamic_link stub_unsigned)
 
     if (LINKER_HAS_NO_AS_NEEDED)
         # The linker may not detect a dependency on pthread in static variable constructors.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -427,6 +427,7 @@ if (TARGET TBB::tbb)
         $<TARGET_PROPERTY:TBB::tbb,INTERFACE_INCLUDE_DIRECTORIES>)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH_USE_ORIGIN TRUE)
     set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$ORIGIN")
+    target_compile_definitions(test_dynamic_link PRIVATE "TBBLIB_NAME=\"$<TARGET_FILE_NAME:TBB::tbb>\"")
     # set_property(TARGET test_dynamic_link PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:TBB::tbb>")
 
     if (LINKER_HAS_NO_AS_NEEDED)

--- a/test/tbb/stub_unsigned_lib.cpp
+++ b/test/tbb/stub_unsigned_lib.cpp
@@ -1,0 +1,34 @@
+/*
+    Copyright (c) 2025 Intel Corporation
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+//! \file stub_unsigned_lib.cpp
+//! \brief Test for [internal] functionality
+
+#if _WIN32 || _WIN64
+// Make sure the symbol is visible
+#define STUB_EXPORT __declspec(dllexport)
+#else
+// On other platforms check the branch when symbol cannot be resolved by hiding it
+#define STUB_EXPORT __attribute__ ((visibility ("hidden")))
+#endif
+
+#include <cstdlib>
+
+extern "C" {
+STUB_EXPORT void foo() {
+    std::abort();               // Test dynamic link should never call this function
+}
+}

--- a/test/tbb/stub_unsigned_lib.cpp
+++ b/test/tbb/stub_unsigned_lib.cpp
@@ -28,6 +28,15 @@
 #include <cstdlib>
 
 extern "C" {
+
+static int dummy = []() {
+#if _WIN32
+    // Make sure the library is not loaded on Windows in test dynamic link
+    std::abort();
+#endif
+    return 1;
+}();
+
 STUB_EXPORT void foo() {
     std::abort();               // Test dynamic link should never call this function
 }

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -157,10 +157,10 @@ TEST_CASE("Test dynamic_link with existing library") {
 #endif
 }
 
-#if _WIN32 && !defined(__TBB_SKIP_DEPENDENCY_SIGNATURE_VERIFICATION)
-//! Testing dynamic_link with stub library known to be unsigned
-//! \brief \ref requirement
-TEST_CASE("Test dynamic_link does not load unsigned library found in the directory with the test") {
+//! Testing dynamic_link with stub library known to be unsigned (on Windows) and having no exported
+//! symbols (on Linux)
+// \brief \ref requirement
+TEST_CASE("Test dynamic_link with bad library") {
     const int size = PATH_MAX + 1;
     char msg[size] = {0};
     const char* lib_name = TEST_LIBRARY_NAME("stub_unsigned");
@@ -184,11 +184,16 @@ TEST_CASE("Test dynamic_link does not load unsigned library found in the directo
                                                            sizeof(table) / sizeof(table[0]),
                                                            /*handle*/nullptr, load_flags);
     std::snprintf(msg, size, "The library \"%s\" was loaded but should not have been.", path);
-    REQUIRE_MESSAGE(false == link_result, msg);
+
+    // Expectation is that the library will not be loaded because:
+    // a) On Windows the library is unsigned
+    // b) On Linux the library does not have exported symbols
+    const bool expected_link_result = false;
+
+    REQUIRE_MESSAGE(expected_link_result == link_result, msg);
     REQUIRE_MESSAGE(nullptr == handler, "The symbol should not be changed.");
     // TODO: Verify the warning message contains "TBB dynamic link warning: The module
     // \".*stub_unsigned.*.dll\" is unsigned or has invalid signature."
 }
-#endif // _WIN32 && !__TBB_SKIP_DEPENDENCY_SIGNATURE_VERIFICATION
 
 #endif // __TBB_DYNAMIC_LOAD_ENABLED

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -162,12 +162,15 @@ TEST_CASE("Test dynamic_link with existing library") {
 // \brief \ref requirement
 TEST_CASE("Test dynamic_link with bad library") {
     const int size = PATH_MAX + 1;
-    char msg[size] = {0};
     const char* lib_name = TEST_LIBRARY_NAME("stub_unsigned");
     char path[size] = {0};
+
     const std::size_t len = tbb::detail::r1::abs_path(lib_name, path, sizeof(path));
     REQUIRE_MESSAGE((0 < len && len <= PATH_MAX), "The path to the library is not built");
-    std::snprintf(msg, size, "Test prerequisite is not held - the path \"%s\" must exist", path);
+
+    const int msg_size = size + 128; // Path to the file + message
+    char msg[msg_size] = {0};
+    std::snprintf(msg, msg_size, "Test prerequisite is not held - the path \"%s\" must exist", path);
     REQUIRE_MESSAGE(tbb::detail::r1::file_exists(path), msg);
 
     // The library exists, check that it will not be loaded.
@@ -183,7 +186,7 @@ TEST_CASE("Test dynamic_link with bad library") {
     const bool link_result = tbb::detail::r1::dynamic_link(lib_name, table,
                                                            sizeof(table) / sizeof(table[0]),
                                                            /*handle*/nullptr, load_flags);
-    std::snprintf(msg, size, "The library \"%s\" was loaded but should not have been.", path);
+    std::snprintf(msg, msg_size, "The library \"%s\" was loaded but should not have been.", path);
 
     // Expectation is that the library will not be loaded because:
     // a) On Windows the library is unsigned

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -21,7 +21,12 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#define __TBB_NO_IMPLICIT_LINKAGE 1
+
 #include "common/test.h"
+
+// Out-of-line TBB assertion handling routines are instantiated here
+#include "../../src/tbb/assert_impl.h"
 
 enum FOO_TYPE {
     FOO_DUMMY,
@@ -100,8 +105,6 @@ TEST_CASE("Test dynamic_link with non-existing library") {
 //! \brief \ref error_guessing
 TEST_CASE("Test dynamic_link corner cases") {
     std::cout << "Test dynamic_link ''\n";
-    auto library_handle = dlopen(NULL, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
-    std::cout << "manual load library_handle = " << library_handle << "\n";
     test_dynamic_link(nullptr);
     test_dynamic_link("");
 }

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -81,6 +81,7 @@ void test_dynamic_link(const char* lib_name) {
         REQUIRE_MESSAGE((foo1_handler && foo2_handler), "The symbols are corrupted by dynamic_link");
         REQUIRE_MESSAGE((foo1_handler() == FOO_IMPLEMENTATION && foo2_handler() == FOO_IMPLEMENTATION),
                 "dynamic_link returned the successful code but symbol(s) are wrong");
+        std::cout << "True branch!\n";
     } else {
         REQUIRE_MESSAGE((foo1_handler == dummy_foo1 && foo2_handler == dummy_foo2), "The symbols are corrupted by dynamic_link");
     }
@@ -97,6 +98,20 @@ TEST_CASE("Test dynamic_link with non-existing library") {
 
 //! Testing dynamic_link
 //! \brief \ref error_guessing
-TEST_CASE("Test dynamic_link") {
+TEST_CASE("Test dynamic_link corner cases") {
+    std::cout << "Test dynamic_link ''\n";
+    auto library_handle = dlopen(NULL, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
+    std::cout << "manual load library_handle = " << library_handle << "\n";
+    test_dynamic_link(nullptr);
     test_dynamic_link("");
 }
+
+
+// TODO:
+// 1. Check that the load happens even without DYNAMIC_LINK_BUILD_ABSOLUTE_PATH flag
+//    - Linux expected behavior: RUNPATH is used
+//    - Windows expected behavior: Application directory is looked into
+// 2. Check that stub unsigned binary is not loaded (Windows only) (if there is and there is no __TBB_SKIP_DEPENDENCY_SIGNATURE_VERIFICATION specified)
+//    - If TBB_DYNAMIC_LINK_WARNING is specified check corresponding regexp is printed.
+// 3. Check that signed library is loaded (Windows only)
+//    - Test needs to check itself that the library is signed

--- a/test/tbb/test_dynamic_link.cpp
+++ b/test/tbb/test_dynamic_link.cpp
@@ -122,6 +122,8 @@ TEST_CASE("Test dynamic_link corner cases") {
 
 
 #if __TBB_DYNAMIC_LOAD_ENABLED
+
+#if !__TBB_WIN8UI_SUPPORT
 //! Testing dynamic_link with existing library
 //! \brief \ref requirement
 TEST_CASE("Test dynamic_link with existing library") {
@@ -156,6 +158,7 @@ TEST_CASE("Test dynamic_link with existing library") {
                     "dynamic_link returned successful code but symbol returned incorrect result");
 #endif
 }
+#endif                          // !__TBB_WIN8UI_SUPPORT
 
 //! Testing dynamic_link with stub library known to be unsigned (on Windows) and having no exported
 //! symbols (on Linux)
@@ -164,14 +167,15 @@ TEST_CASE("Test dynamic_link with bad library") {
     const int size = PATH_MAX + 1;
     const char* lib_name = TEST_LIBRARY_NAME("stub_unsigned");
     char path[size] = {0};
-
-    const std::size_t len = tbb::detail::r1::abs_path(lib_name, path, sizeof(path));
-    REQUIRE_MESSAGE((0 < len && len <= PATH_MAX), "The path to the library is not built");
-
     const int msg_size = size + 128; // Path to the file + message
     char msg[msg_size] = {0};
+
+#if !__TBB_WIN8UI_SUPPORT
+    const std::size_t len = tbb::detail::r1::abs_path(lib_name, path, sizeof(path));
+    REQUIRE_MESSAGE((0 < len && len <= PATH_MAX), "The path to the library is not built");
     std::snprintf(msg, msg_size, "Test prerequisite is not held - the path \"%s\" must exist", path);
     REQUIRE_MESSAGE(tbb::detail::r1::file_exists(path), msg);
+#endif
 
     // The library exists, check that it will not be loaded.
     void (*handler)() = nullptr;


### PR DESCRIPTION
Extending test_dynamic_link to test recently updated dynamic loading functionality, including:
- Checking that signature verification is required to load the library.
- Loading can be done without building an absolute path.
