### PR TITLE
Fix deprecation warning about <ciso646> header

### DIFF
--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -509,7 +509,11 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 // https://github.com/doctest/doctest/issues/126
 // https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
+#if DOCTEST_CPLUSPLUS >= 201703L && __has_include(<version>)
+#include <version>
+#else
 #include <ciso646>
+#endif
 #endif // clang
 
 #ifdef _LIBCPP_VERSION

--- a/test/common/doctest.h
+++ b/test/common/doctest.h
@@ -1,5 +1,5 @@
 /*
-    Modifications Copyright (c) 2020-2023 Intel Corporation
+    Modifications Copyright (c) 2020-2025 Intel Corporation
     Modifications Licensed under the Apache License, Version 2.0;
     You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 */


### PR DESCRIPTION
### Description 
Fixes the following warning:
```
error: "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Werror,-W#warnings]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
      |    ^
```
Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
