### PR TITLE
Add an assertion in post coroutine-resume cleanup

### DIFF
--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -172,6 +172,7 @@ void task_dispatcher::do_post_resume_action() {
         task_dispatcher* to_cleanup = static_cast<task_dispatcher*>(td->my_post_resume_arg);
         // Release coroutine's reference to my_arena
         td->my_arena->on_thread_leaving(arena::ref_external);
+        __TBB_ASSERT(is_alive(td->my_arena->my_guard), "The arena should not have been destroyed");
         // Cache the coroutine for possible later re-usage
         td->my_arena->my_co_cache.push(to_cleanup);
         break;


### PR DESCRIPTION
### Description
An arena keeps track of its worker and external threads [separately](https://github.com/uxlfoundation/oneTBB/blob/982d9cb27fbd366e9d1c046f1ada8d29b00f7538/src/tbb/arena.h#L262). (After the last thread reference is removed, the arena is destroyed.) Created coroutines are also counted as additional external references. Their references are added to the arena during `suspend` and removed during post-resume cleanup.

`task_dispatcher::resume` (which ends with the post-resume action) is called from either [`suspend`](https://github.com/uxlfoundation/oneTBB/blob/982d9cb27fbd366e9d1c046f1ada8d29b00f7538/src/tbb/task.cpp#L106) or [`resume_task::execute`](https://github.com/uxlfoundation/oneTBB/blob/982d9cb27fbd366e9d1c046f1ada8d29b00f7538/src/tbb/task_dispatcher.h#L90). Both of these can only be done within a task (a running task or a resume task, respectively). Hence, when post-resume cleanup removes the coroutine's arena reference, there is still a reference in the arena to the thread that is executing this task.

The added assertion ensures the arena is intact after removing the coroutine reference.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown