### PR TITLE
Prevent copying of scoped_parallel_phase

### DIFF
--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -504,7 +504,7 @@ public:
         r1::exit_parallel_phase(this, static_cast<std::uintptr_t>(with_fast_leave));
     }
 
-    class scoped_parallel_phase {
+    class scoped_parallel_phase : no_copy {
         task_arena& arena;
         bool one_time_fast_leave;
     public:


### PR DESCRIPTION
### Description 
Fix a Rule of Three violation by forbidding `scoped_parallel_phase` copy-construction and copy-assignment. Without this, one could copy a `scoped_parallel_phase`, causing an underflow (or an assertion failure) when the destructor ends the parallel phase without a matching start.

### Type of change
- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown