### PR TITLE
Flow Graph deduction guides simplification + support for newly added body types

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_nodes_deduction.h
+++ b/include/oneapi/tbb/detail/_flow_graph_nodes_deduction.h
@@ -25,29 +25,29 @@ namespace d2 {
 
 template <typename Input>
 struct declare_input_type {
-    using input_type = Input;
+    using input_type = std::decay_t<Input>;
 };
 
 template <>
 struct declare_input_type<d1::flow_control> {};
 
 template <typename Input, typename Output>
-struct body_types : declare_input_type<std::decay_t<Input>> {
+struct body_types : declare_input_type<Input> {
     using output_type = std::decay_t<Output>;
 };
 
 template <typename P>
-struct extract_member_function_types;
+struct extract_callable_object_types;
 
 template <typename Body, typename Input, typename Output>
-struct extract_member_function_types<Output (Body::*)(Input)> : body_types<Input, Output> {};
+struct extract_callable_object_types<Output (Body::*)(Input)> : body_types<Input, Output> {};
 
 template <typename Body, typename Input, typename Output>
-struct extract_member_function_types<Output (Body::*)(Input) const> : body_types<Input, Output> {};
+struct extract_callable_object_types<Output (Body::*)(Input) const> : body_types<Input, Output> {};
 
 // Body is represented as a callable object - extract types from the pointer to operator()
 template <typename Body>
-struct extract_body_types : extract_member_function_types<decltype(&Body::operator())> {};
+struct extract_body_types : extract_callable_object_types<decltype(&Body::operator())> {};
 
 // Body is represented as a pointer to function
 template <typename Input, typename Output>
@@ -55,7 +55,7 @@ struct extract_body_types<Output (*)(Input)> : body_types<Input, Output> {};
 
 // Body is represented as a pointer to member function
 template <typename Input, typename Output>
-struct extract_body_types<Output (Input::*)()> : body_types<Input, Output> {};
+struct extract_body_types<Output (Input::*)() const> : body_types<Input, Output> {};
 
 // Body is represented as a pointer to member object
 template <typename Input, typename Output>

--- a/test/conformance/conformance_flowgraph.h
+++ b/test/conformance/conformance_flowgraph.h
@@ -811,4 +811,65 @@ void test_with_reserving_join_node_class() {
         if at least one successor accepts the tuple must consume messages");
 }
 }
+
+#if __TBB_CPP17_DEDUCTION_GUIDES_PRESENT
+namespace deduction_guides_testing {
+
+template <typename Input, typename Output>
+struct callable_object_body_base {
+    using input_type = std::decay_t<Input>;
+    using output_type = std::decay_t<Output>;
+};
+
+template <typename Input, typename Output, bool IsConst>
+struct callable_object_body : callable_object_body_base<Input, Output> {
+    Output operator()(Input) { return Output{}; }
+};
+
+template <typename Input, typename Output>
+struct callable_object_body<Input, Output, /*IsConst = */true> : callable_object_body_base<Input, Output> {
+    Output operator()(Input) const { return Output{}; }
+};
+
+template <typename Input, typename Output>
+Output function_body(Input) { return Output{}; }
+
+template <typename Output>
+struct Input {
+    Output member_object_body;
+    Output member_function_body() const { return Output{}; }
+};
+
+template <typename Body>
+struct read_types {
+    using input_type = typename Body::input_type;
+    using output_type = typename Body::output_type;
+};
+
+template <typename Input, typename Output>
+struct read_types<Output (Input::*)> {
+    using input_type = std::decay_t<Input>;
+    using output_type = std::decay_t<Output>;
+};
+
+template <typename Input, typename Output>
+struct read_types<Output (Input::*)() const> {
+    using input_type = std::decay_t<Input>;
+    using output_type = std::decay_t<Output>;
+};
+
+template <typename Input, typename Output>
+struct read_types<Output (*)(Input)> {
+    using input_type = std::decay_t<Input>;
+    using output_type = std::decay_t<Output>;
+};
+
+template <typename Body>
+using input_type = typename read_types<Body>::input_type;
+
+template <typename Body>
+using output_type = typename read_types<Body>::output_type;
+
+} // namespace deduction_guides_testing
+#endif
 #endif // __TBB_test_conformance_conformance_flowgraph_H


### PR DESCRIPTION
### Description 
_Add a comprehensive description of proposed changes_
Simplification for deduction guides for Flow Graph functional nodes to avoid body  types detection twice.
Added support for bodies expressed as pointers to member functions and member objects (supported by std::invoke).
+ tests extensions

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
