### PR TITLE
Replace windows-2019 (deprecated) runner with windows-11-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,14 +352,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
-            generator: Visual Studio 16 2019
+          - os: windows-11-arm
+            generator: Visual Studio 17 2022
             c_compiler: cl
             cxx_compiler: cl
             std: 14
             build_type: relwithdebinfo
             preview: 'ON'
-            job_name: examples_windows_cl2019_cxx14_relwithdebinfo_preview=ON
+            job_name: examples_windows_11_arm_cl2022_cxx14_relwithdebinfo_preview=ON
           - os: windows-2022
             generator: Visual Studio 17 2022
             c_compiler: cl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,13 +252,13 @@ jobs:
             preview: 'ON'
             job_name: windows_cl2022_cxx14_relwithdebinfo_preview=ON
           - os: windows-11-arm
-            generator: Visual Studio 16 2019
+            generator: Visual Studio 17 2022
             c_compiler: cl
             cxx_compiler: cl
             std: 20
             build_type: release
             preview: 'ON'
-            job_name: windows_11_arm_cl2019_cxx20_release_preview=ON-DBUILD_SHARED_LIBS=OFF
+            job_name: windows_11_arm_cl2022_cxx20_release_preview=ON-DBUILD_SHARED_LIBS=OFF
             cmake_static: -DBUILD_SHARED_LIBS=OFF
           - os: windows-2022
             generator: Visual Studio 17 2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,14 +251,14 @@ jobs:
             build_type: relwithdebinfo
             preview: 'ON'
             job_name: windows_cl2022_cxx14_relwithdebinfo_preview=ON
-          - os: windows-2019
+          - os: windows-11-arm
             generator: Visual Studio 16 2019
             c_compiler: cl
             cxx_compiler: cl
             std: 20
             build_type: release
             preview: 'ON'
-            job_name: windows_cl2019_cxx20_release_preview=ON-DBUILD_SHARED_LIBS=OFF
+            job_name: windows_11_arm_cl2019_cxx20_release_preview=ON-DBUILD_SHARED_LIBS=OFF
             cmake_static: -DBUILD_SHARED_LIBS=OFF
           - os: windows-2022
             generator: Visual Studio 17 2022


### PR DESCRIPTION
### Description 
windows-2019 runner is deprecated and will be unsupported after June 30, 2025. 

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [X] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
