### PR TITLE
Fix lifetime issue with reference_vertex

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -159,9 +159,6 @@ public:
         auto last_iterator = my_msg_reference_vertices.cbefore_begin();
 
         for (auto& msg_waiter : my_msg_wait_context_vertices) {
-            // If the task is created by the thread outside the graph arena, the lifetime of the thread reference vertex
-            // may be shorter that the lifetime of the task, so thread reference vertex approach cannot be used
-            // and the task should be associated with the msg wait context itself
             d1::wait_tree_vertex_interface* ref_vertex = r1::get_thread_reference_vertex(msg_waiter);
             last_iterator = my_msg_reference_vertices.emplace_after(last_iterator,
                                                                     ref_vertex);
@@ -449,10 +446,6 @@ inline graph_task::graph_task(graph& g, d1::small_object_allocator& allocator,
     , priority(node_priority)
     , my_allocator(allocator)
 {
-    // If the task is created by the thread outside the graph arena, the lifetime of the thread reference vertex
-    // may be shorter that the lifetime of the task, so thread reference vertex approach cannot be used
-    // and the task should be associated with the graph wait context itself
-    // TODO: consider how reference counting can be improved for such a use case. Most common example is the async_node
     d1::wait_context_vertex* graph_wait_context_vertex = &my_graph.get_wait_context_vertex();
     my_reference_vertex = r1::get_thread_reference_vertex(graph_wait_context_vertex);
     __TBB_ASSERT(my_reference_vertex, nullptr);

--- a/include/oneapi/tbb/detail/_flow_graph_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_impl.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -146,8 +147,6 @@ private:
     friend graph_task* prioritize_task(graph& g, graph_task& gt);
 };
 
-inline bool is_this_thread_in_graph_arena(graph& g);
-
 #if __TBB_PREVIEW_FLOW_GRAPH_TRY_PUT_AND_WAIT
 class trackable_messages_graph_task : public graph_task {
 public:
@@ -163,9 +162,7 @@ public:
             // If the task is created by the thread outside the graph arena, the lifetime of the thread reference vertex
             // may be shorter that the lifetime of the task, so thread reference vertex approach cannot be used
             // and the task should be associated with the msg wait context itself
-            d1::wait_tree_vertex_interface* ref_vertex = is_this_thread_in_graph_arena(g) ?
-                                                         r1::get_thread_reference_vertex(msg_waiter) :
-                                                         msg_waiter;
+            d1::wait_tree_vertex_interface* ref_vertex = r1::get_thread_reference_vertex(msg_waiter);
             last_iterator = my_msg_reference_vertices.emplace_after(last_iterator,
                                                                     ref_vertex);
             ref_vertex->reserve(1);
@@ -420,7 +417,6 @@ private:
     friend void activate_graph(graph& g);
     friend void deactivate_graph(graph& g);
     friend bool is_graph_active(graph& g);
-    friend bool is_this_thread_in_graph_arena(graph& g);
     friend graph_task* prioritize_task(graph& g, graph_task& arena_task);
     friend void spawn_in_graph_arena(graph& g, graph_task& arena_task);
     friend void enqueue_in_graph_arena(graph &g, graph_task& arena_task);
@@ -458,8 +454,7 @@ inline graph_task::graph_task(graph& g, d1::small_object_allocator& allocator,
     // and the task should be associated with the graph wait context itself
     // TODO: consider how reference counting can be improved for such a use case. Most common example is the async_node
     d1::wait_context_vertex* graph_wait_context_vertex = &my_graph.get_wait_context_vertex();
-    my_reference_vertex = is_this_thread_in_graph_arena(g) ? r1::get_thread_reference_vertex(graph_wait_context_vertex)
-                                                           : graph_wait_context_vertex;
+    my_reference_vertex = r1::get_thread_reference_vertex(graph_wait_context_vertex);
     __TBB_ASSERT(my_reference_vertex, nullptr);
     my_reference_vertex->reserve();
 }
@@ -511,11 +506,6 @@ inline void deactivate_graph(graph& g) {
 
 inline bool is_graph_active(graph& g) {
     return g.my_is_active;
-}
-
-inline bool is_this_thread_in_graph_arena(graph& g) {
-    __TBB_ASSERT(g.my_task_arena && g.my_task_arena->is_active(), nullptr);
-    return r1::execution_slot(*g.my_task_arena) != d1::slot_id(-1);
 }
 
 inline graph_task* prioritize_task(graph& g, graph_task& gt) {

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -197,18 +197,18 @@ public:
     {}
 
     void reserve(std::uint32_t delta = 1) override {
-        reserve_impl(delta);
+        reserve_post_increment(delta);
     }
 
     void release(std::uint32_t delta = 1) override {
-        release_impl(delta);
+        release_pre_decrement(delta);
     }
 
-    std::uint32_t get_num_child() {
+    std::uint32_t get_num_children() {
         return static_cast<std::uint32_t>(m_ref_count.load(std::memory_order_acquire));
     }
 protected:
-    std::uint64_t reserve_impl(std::uint32_t delta) {
+    std::uint64_t reserve_post_increment(std::uint32_t delta) {
         auto ref = m_ref_count.fetch_add(static_cast<std::uint64_t>(delta));
         if (ref == 0) {
             my_parent->reserve();
@@ -216,7 +216,7 @@ protected:
         return ref;
     }
 
-    std::uint64_t release_impl(std::uint32_t delta) {
+    std::uint64_t release_pre_decrement(std::uint32_t delta) {
         auto parent = my_parent;
         std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
         if (ref == 0) {

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -197,34 +197,24 @@ public:
     {}
 
     void reserve(std::uint32_t delta = 1) override {
-        reserve_post_increment(delta);
+        auto ref = m_ref_count.fetch_add(static_cast<std::uint64_t>(delta));
+        if (ref == 0) {
+            my_parent->reserve();
+        }
     }
 
     void release(std::uint32_t delta = 1) override {
-        release_pre_decrement(delta);
+        auto parent = my_parent;
+        std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
+        if (ref == 0) {
+            parent->release();
+        }
     }
 
     std::uint32_t get_num_children() {
         return static_cast<std::uint32_t>(m_ref_count.load(std::memory_order_acquire));
     }
 protected:
-    std::uint64_t reserve_post_increment(std::uint32_t delta) {
-        auto ref = m_ref_count.fetch_add(static_cast<std::uint64_t>(delta));
-        if (ref == 0) {
-            my_parent->reserve();
-        }
-        return ref;
-    }
-
-    std::uint64_t release_pre_decrement(std::uint32_t delta) {
-        auto parent = my_parent;
-        std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
-        if (ref == 0) {
-            parent->release();
-        }
-        return ref;
-    }
-private:
     wait_tree_vertex_interface* my_parent;
     std::atomic<std::uint64_t> m_ref_count;
 };

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -191,34 +191,6 @@ private:
     wait_context m_wait;
 };
 
-class reference_vertex : public wait_tree_vertex_interface {
-public:
-    reference_vertex(wait_tree_vertex_interface* parent, std::uint32_t ref_count) : my_parent{parent}, m_ref_count{ref_count}
-    {}
-
-    void reserve(std::uint32_t delta = 1) override {
-        auto ref = m_ref_count.fetch_add(static_cast<std::uint64_t>(delta));
-        if (ref == 0) {
-            my_parent->reserve();
-        }
-    }
-
-    void release(std::uint32_t delta = 1) override {
-        auto parent = my_parent;
-        std::uint64_t ref = m_ref_count.fetch_sub(static_cast<std::uint64_t>(delta)) - static_cast<std::uint64_t>(delta);
-        if (ref == 0) {
-            parent->release();
-        }
-    }
-
-    std::uint32_t get_num_children() {
-        return static_cast<std::uint32_t>(m_ref_count.load(std::memory_order_acquire));
-    }
-protected:
-    wait_tree_vertex_interface* my_parent;
-    std::atomic<std::uint64_t> m_ref_count;
-};
-
 struct execution_data {
     task_group_context* context{};
     slot_id original_slot{};

--- a/include/oneapi/tbb/detail/_task.h
+++ b/include/oneapi/tbb/detail/_task.h
@@ -22,7 +22,6 @@
 #include "_assert.h"
 #include "_template_helpers.h"
 #include "_small_object_pool.h"
-#include "../cache_aligned_allocator.h"
 
 #include "../profiling.h"
 

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -488,7 +488,7 @@ public:
     }
 private:
     static constexpr std::uint64_t m_orphaned_bit = 1ull << 63;
-    static constexpr std::uint64_t m_overflow_mask = ~((1ull << 32) - 1) & ~m_orphaned_bit;
+    static constexpr std::uint64_t m_overflow_mask = ~(((1ull << 32) - 1) | m_orphaned_bit);
     wait_tree_vertex_interface& m_parent;
     std::atomic<std::uint64_t> m_ref_count;
 

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -460,7 +460,7 @@ public:
         // Masking out the orphaned bit to check actual number of references
         if ((ref & ~m_orphaned_bit) == 0) {
             parent->release();
-            // The owning thread has abandoned this vertex so it is our responsibility to finalize it
+            // If the owning thread has abandoned this vertex, it is our responsibility to destroy it
             if (ref & m_orphaned_bit) {
                 finalize();
             }

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -514,8 +515,7 @@ public:
 
         for (auto& elem : m_reference_vertex_map) {
             d1::reference_vertex*& node = elem.second;
-            node->~reference_vertex();
-            cache_aligned_deallocate(node);
+            node->destroy();
             poison_pointer(node);
         }
 

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -455,7 +455,7 @@ public:
 
     void release(std::uint32_t delta = 1) override {
         // Saving a reference to the parent before decrementing the reference count
-        // because it won't be safe to access any members after that
+        // because other thread can destroy the vertex after the decrement
         auto& parent = m_parent;
         std::uint64_t ref = m_ref_count.fetch_sub(delta) - delta;
         __TBB_ASSERT_EX((ref & m_overflow_mask) == 0, "Underflow is detected");

--- a/src/tbb/scheduler_common.h
+++ b/src/tbb/scheduler_common.h
@@ -486,13 +486,18 @@ public:
         this->~thread_reference_vertex();
         cache_aligned_deallocate(this);
     }
+
+#if TBB_USE_ASSERT
+    bool is_orphaned() {
+        return m_ref_count.load(std::memory_order_relaxed) & m_orphaned_bit;
+    }
+#endif
+
 private:
     static constexpr std::uint64_t m_orphaned_bit = 1ull << 63;
     static constexpr std::uint64_t m_overflow_mask = ~(((1ull << 32) - 1) | m_orphaned_bit);
     wait_tree_vertex_interface& m_parent;
     std::atomic<std::uint64_t> m_ref_count;
-
-    friend d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex_interface*);
 };
 
 class alignas (max_nfs_size) task_dispatcher {

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -237,8 +237,8 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
         if (reference_map.size() > max_reference_vertex_map_size) {
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
-                if (it->second->get_num_child() == 0) {
-                    it->second->destroy();
+                if (it->second->get_num_children() == 0) {
+                    it->second->release_ownership();
                     it = reference_map.erase(it);
                 } else {
                     ++it;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -237,10 +237,10 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
         if (reference_map.size() > max_reference_vertex_map_size) {
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
-                __TBB_ASSERT(!(it->second->m_ref_count.load(std::memory_order_relaxed) & it->second->m_orphaned_bit),
-                    "the orphaned bit should not yet be set");
-                if (it->second->get_num_children() == 0) {
-                    auto& node = it->second;
+                __TBB_ASSERT(it->second, nullptr);
+                thread_reference_vertex*& node = it->second;
+                __TBB_ASSERT(!node->is_orphaned(), "the orphaned bit should not yet be set");
+                if (node->get_num_children() == 0) {
                     node->destroy();
                     it = reference_map.erase(it);
                 } else {

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -238,7 +238,9 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
                 if (it->second->get_num_children() == 0) {
-                    it->second->release_ownership();
+                    auto& node = it->second;
+                    node->~thread_reference_vertex();
+                    cache_aligned_deallocate(node);
                     it = reference_map.erase(it);
                 } else {
                     ++it;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -238,7 +238,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
                 if (it->second->get_num_child() == 0) {
-                    it->second->~reference_vertex();
+                    it->second->~thread_reference_vertex();
                     cache_aligned_deallocate(it->second);
                     it = reference_map.erase(it);
                 } else {

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -237,10 +237,10 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
         if (reference_map.size() > max_reference_vertex_map_size) {
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
+                __TBB_ASSERT(!(it->second->m_ref_count.load(std::memory_order_relaxed) & it->second->m_orphaned_bit),
+                    "the orphaned bit should not yet be set");
                 if (it->second->get_num_children() == 0) {
                     auto& node = it->second;
-                    __TBB_ASSERT(!(node->m_ref_count.load(std::memory_order_relaxed) & node->m_orphaned_bit),
-                        "the orphaned bit should not yet be set");
                     node->destroy();
                     it = reference_map.erase(it);
                 } else {

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -239,8 +239,9 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
             for (auto it = reference_map.begin(); it != reference_map.end();) {
                 if (it->second->get_num_children() == 0) {
                     auto& node = it->second;
-                    node->~thread_reference_vertex();
-                    cache_aligned_deallocate(node);
+                    __TBB_ASSERT(!(node->m_ref_count.load(std::memory_order_relaxed) & node->m_orphaned_bit),
+                        "the orphaned bit cannot be set");
+                    node->finalize();
                     it = reference_map.erase(it);
                 } else {
                     ++it;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -226,7 +227,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
     __TBB_ASSERT(top_wait_context, nullptr);
     auto& dispatcher = *governor::get_thread_data()->my_task_dispatcher;
 
-    d1::reference_vertex* ref_counter{nullptr};
+    thread_reference_vertex* ref_counter{nullptr};
     auto& reference_map = dispatcher.m_reference_vertex_map;
     auto pos = reference_map.find(top_wait_context);
     if (pos != reference_map.end()) {
@@ -247,7 +248,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
         }
 
         reference_map[top_wait_context] = ref_counter =
-            new (cache_aligned_allocate(sizeof(d1::reference_vertex))) d1::reference_vertex(top_wait_context, 0);
+            new (cache_aligned_allocate(sizeof(thread_reference_vertex))) thread_reference_vertex(top_wait_context, 0);
     }
 
     return ref_counter;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -241,7 +241,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
                     auto& node = it->second;
                     __TBB_ASSERT(!(node->m_ref_count.load(std::memory_order_relaxed) & node->m_orphaned_bit),
                         "the orphaned bit should not yet be set");
-                    node->finalize();
+                    node->destroy();
                     it = reference_map.erase(it);
                 } else {
                     ++it;
@@ -250,7 +250,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
         }
 
         reference_map[top_wait_context] = ref_counter =
-            new (cache_aligned_allocate(sizeof(thread_reference_vertex))) thread_reference_vertex(top_wait_context, 0);
+            new (cache_aligned_allocate(sizeof(thread_reference_vertex))) thread_reference_vertex(*top_wait_context, 0);
     }
 
     return ref_counter;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -238,8 +238,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
             // TODO: Research the possibility of using better approach for a clean-up
             for (auto it = reference_map.begin(); it != reference_map.end();) {
                 if (it->second->get_num_child() == 0) {
-                    it->second->~thread_reference_vertex();
-                    cache_aligned_deallocate(it->second);
+                    it->second->destroy();
                     it = reference_map.erase(it);
                 } else {
                     ++it;

--- a/src/tbb/task.cpp
+++ b/src/tbb/task.cpp
@@ -240,7 +240,7 @@ d1::wait_tree_vertex_interface* get_thread_reference_vertex(d1::wait_tree_vertex
                 if (it->second->get_num_children() == 0) {
                     auto& node = it->second;
                     __TBB_ASSERT(!(node->m_ref_count.load(std::memory_order_relaxed) & node->m_orphaned_bit),
-                        "the orphaned bit cannot be set");
+                        "the orphaned bit should not yet be set");
                     node->finalize();
                     it = reference_map.erase(it);
                 } else {

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
     Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -2067,4 +2068,34 @@ TEST_CASE("worker threads occupy slots in correct range") {
     }
 
     while (counter < 42) { utils::yield(); }
+}
+
+//! \brief \ref error_guessing
+TEST_CASE("Stress test enqueue with task_group from multiple threads") {
+    constexpr std::size_t task_groups_per_thread = 1500;
+    constexpr std::size_t task_submits_per_task_group = 100;
+
+    std::size_t num_threads = utils::get_platform_max_threads();
+    std::vector<tbb::task_arena> arenas(num_threads);
+    std::vector<tbb::task_group> tg(task_groups_per_thread);
+
+    for (std::size_t i = 0; i < 10; ++i) {
+        utils::NativeParallelFor(num_threads, [&] (std::size_t thread_index) {
+            for (std::size_t j = 0; j < task_groups_per_thread; ++j) {
+                for (std::size_t k = 0; k < task_submits_per_task_group; ++k) {
+                    arenas[thread_index].enqueue(tg[j].defer([&] {
+                        utils::doDummyWork(100);
+                    }));
+                }
+            }
+        });
+
+        utils::NativeParallelFor(num_threads, [&] (std::size_t thread_index) {
+            for (std::size_t j = 0; j < task_groups_per_thread; ++j) {
+                arenas[thread_index].execute([&] {
+                    tg[j].wait();
+                });
+            }
+        });
+    }
 }


### PR DESCRIPTION
### Description 
To improve the scalability of `wait_context` usage across several oneTBB parallel algorithms and structures, the `wait_context_vertex` class was introduced. In particular, a special `reference_vertex` class was added to track the number of references to a `wait_context` from a specific thread.

For example, `task_group` has a `wait_context_vertex` that is bound to a single `wait_context`. When a task is submitted to the task_group, `get_thread_reference_vertex` is invoked to retrieve a `reference_vertex` bound to the calling thread and associated with the parent `wait_context_vertex`. For each `reference_vertex`, the first call to `reserve` acquires the actual wait_context, and the last call to `release` releases it accordingly. When the corresponding arena associated with the calling thread is destroyed, the `reference_vertex` objects are also deallocated.

While this approach works well for blocking APIs like parallel_for_each, it poses issues for asynchronous APIs like task_group. A task may be deferred on one thread but submitted for execution later in a different arena. For example:
```cpp
    tbb::task_group tg;
    tbb::task_handle task;
    std::thread([&] { task = tg.defer(body); }).join();
    tg.run(std::move(task));
    tg.wait();
```
In this scenario, the lifetime of the task's `reference_vertex` is tied to the thread that called `task_group::defer`. Consequently, when that thread terminates, the vertex may be deallocated before the task is finalized. During finalization, the destructor of `task_handle_task` attempts to access the now-invalid vertex to release its reference, resulting in a failure.

This patch addresses the issue by introducing an additional level of reference counting specifically for the lifetime management of the vertex. By default, a reference is held by the thread that allocates the vertex, and a second reference is added upon the first call to `reserve()`. During the final `release()` call, the implementation checks whether the owning thread has already abandoned the vertex. If so, the responsibility of deallocating the vertex falls to the current thread.

Is a prerequisite for #1784

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility

- [ ] Yes
- [x] No - `reference_vertex` class was created only in library and the entry point returned a pointer to the interface class `wait_vertex_interface`, and the code in headers interact with it via virtual methods. So, it should be safe to return a pointer to new `thread_reference_vertex` instead because the correct methods will be resolved through polymorphism.
- [ ] Unknown