### PR TITLE
Fix ASan detection on clang

### DIFF
--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -41,6 +41,22 @@
 #include <emscripten/stack.h>
 #endif
 
+// ASan detection: define HAS_SANITIZE_ADDRESS regardless
+// of the compiler when we are in an address-sanitized build.
+#if defined(HAS_SANITIZE_ADDRESS)
+#undef HAS_SANITIZE_ADDRESS
+#endif
+
+#if defined(__SANITIZE_ADDRESS__)
+// gcc
+#define HAS_SANITIZE_ADDRESS
+#elif defined(__has_feature)
+// clang
+#if __has_feature(address_sanitizer)
+#define HAS_SANITIZE_ADDRESS
+#endif
+#endif
+
 namespace tbb {
 namespace detail {
 namespace r1 {
@@ -169,7 +185,7 @@ static void get_stack_attributes(std::uintptr_t& stack_base, std::size_t& stack_
 
     // Points to the lowest addressable byte of a stack.
     void* stack_limit = nullptr;
-#if __linux__ && !__bg__ && !defined(__SANITIZE_ADDRESS__)
+#if __linux__ && !__bg__ && !defined(HAS_SANITIZE_ADDRESS)
     size_t np_stack_size = 0;
     pthread_attr_t np_attr_stack;
     if (0 == pthread_getattr_np(pthread_self(), &np_attr_stack)) {


### PR DESCRIPTION
### Description 

This patch fixes ASan detection on clang and derivatives. The current behaviour across toolchains can be seen [here](https://godbolt.org/z/1r5cxj5Gf), while the effect of this patch is shown [here](https://godbolt.org/z/1qTv8vc58).

Fixes #1801 

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users

### Other information
