### PR TITLE
Avoid `nullptr` member function call if key hasn't been found by `hash_buffer_impl::find_element_ref_with_key`

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_tagged_buffer_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_tagged_buffer_impl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/include/oneapi/tbb/detail/_flow_graph_tagged_buffer_impl.h
+++ b/include/oneapi/tbb/detail/_flow_graph_tagged_buffer_impl.h
@@ -303,7 +303,7 @@ public:
     bool find_ref_with_key(const Knoref& k, pointer_type &v) {
         element_type* element_ptr = nullptr;
         bool res = find_element_ref_with_key(k, element_ptr);
-        v = element_ptr->get_value_ptr();
+        if(res) v = element_ptr->get_value_ptr();
         return res;
     }
 


### PR DESCRIPTION
### Description 

This patch avoids `hash_buffer_impl:: find_ref_with_key` trying to retrieve the searched value when `hash_buffer_impl::find_element_ref_with_key` returns no matches. This looks aligned with the intended semantics of the function as stated by the comment:

```cpp
// returns true and sets v to array element if found, else returns false.
    bool find_ref_with_key(const Knoref& k, pointer_type &v) {
```

Fixes #1799 

### Type of change

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added
- [x] not needed, **already reproduced by existing tests, see #1799**

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown
