### PR TITLE
Enable multiple core type constraints and identify additional core type

### DIFF
--- a/include/oneapi/tbb/version.h
+++ b/include/oneapi/tbb/version.h
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@
 // Update version
 #define TBB_VERSION_MINOR 13
 // "Patch" version for custom releases
-#define TBB_VERSION_PATCH 0
+#define TBB_VERSION_PATCH 1
 // Suffix string
 #define __TBB_VERSION_SUFFIX ""
 // Full official version string
@@ -44,7 +45,7 @@
 // OneAPI oneTBB specification version
 #define ONETBB_SPEC_VERSION "1.0"
 // Full interface version
-#define TBB_INTERFACE_VERSION 12130
+#define TBB_INTERFACE_VERSION 12131
 // Major interface version
 #define TBB_INTERFACE_VERSION_MAJOR (TBB_INTERFACE_VERSION/1000)
 // Minor interface version

--- a/src/tbb/governor.cpp
+++ b/src/tbb/governor.cpp
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -565,7 +566,7 @@ void constraints_assertion(d1::constraints c) {
     int* core_types_begin = system_topology::core_types_indexes;
     int* core_types_end = system_topology::core_types_indexes + system_topology::core_types_count;
     __TBB_ASSERT_RELEASE(c.core_type == system_topology::automatic ||
-        (is_topology_initialized && std::find(core_types_begin, core_types_end, c.core_type) != core_types_end),
+        (is_topology_initialized && (!c.single_core_type() || std::find(core_types_begin, core_types_end, c.core_type) != core_types_end)),
         "The constraints::core_type value is not known to the library. Use tbb::info::core_types() to get the list of possible values.");
 }
 

--- a/src/tbb/tbb.rc
+++ b/src/tbb/tbb.rc
@@ -1,4 +1,4 @@
-// Copyright (c) 2005-2024 Intel Corporation
+// Copyright (c) 2005-2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright 2005-2024 Intel Corporation.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright 2005-2025 Intel Corporation.  All Rights Reserved.\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbb12.dll\0"

--- a/src/tbbbind/tbb_bind.cpp
+++ b/src/tbbbind/tbb_bind.cpp
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2019-2023 Intel Corporation
+    Copyright (c) 2019-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,6 +21,8 @@
 #include "../tbb/assert_impl.h" // Out-of-line TBB assertion handling routines are instantiated here.
 #include "oneapi/tbb/detail/_assert.h"
 #include "oneapi/tbb/detail/_config.h"
+#include "oneapi/tbb/detail/_utils.h"
+#include "oneapi/tbb/info.h"
 
 #if _MSC_VER && !__INTEL_COMPILER && !__clang__
 #pragma warning( push )
@@ -213,6 +216,36 @@ private:
                 }
             }
         }
+
+        // On hybrid CPUs, check if there are cores without L3 cache.
+        if (!core_types_parsing_broken && core_types_number > 1) {
+            // The first core type mask (least performant cores)
+            hwloc_cpuset_t& front = core_types_affinity_masks_list.front();
+            hwloc_cpuset_t lp_mask = hwloc_bitmap_dup(front);
+
+            // Iterate through all L3 cache objects and remove their cores from lp_mask.
+            hwloc_obj_t l3_package = nullptr;
+            while ((l3_package = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, l3_package)) != nullptr ) {
+                hwloc_bitmap_andnot(lp_mask, lp_mask, l3_package->cpuset);
+            }
+
+            if (hwloc_bitmap_iszero(lp_mask)) {
+                // All cores in the front mask have L3 cache, so no need to create a separate core type.
+                hwloc_bitmap_free(lp_mask);
+            } else {
+                hwloc_bitmap_andnot(front, front, lp_mask);
+                if (hwloc_bitmap_iszero(front)) {
+                    // No cores with L3 cache in the front mask, so replace it with the L3-less cores.
+                    hwloc_bitmap_free(front);
+                    front = lp_mask;
+                } else {
+                    // The front mask has SOME cores with L3 cache.
+                    // Create a new least performant (L3-less) core type and add it to the front.
+                    core_types_affinity_masks_list.insert(core_types_affinity_masks_list.begin(), lp_mask);
+                    core_types_indexes_list.push_back(core_types_number++);
+                }
+            }
+        }
 #else /*!__TBBBIND_HWLOC_HYBRID_CPUS_INTERFACES_PRESENT*/
         bool core_types_parsing_broken{true};
 #endif /*__TBBBIND_HWLOC_HYBRID_CPUS_INTERFACES_PRESENT*/
@@ -316,7 +349,13 @@ public:
     void fill_constraints_affinity_mask(affinity_mask input_mask, int numa_node_index, int core_type_index, int max_threads_per_core) {
         __TBB_ASSERT(is_topology_parsed(), "Trying to get access to uninitialized system_topology");
         __TBB_ASSERT(numa_node_index < (int)numa_affinity_masks_list.size(), "Wrong NUMA node id");
-        __TBB_ASSERT(core_type_index < (int)core_types_affinity_masks_list.size(), "Wrong core type id");
+        __TBB_ASSERT(core_type_index == -1 ||
+            // In the multiple core type format, the MSB of the first core_type_id_bits bits represents the highest core type id
+            (tbb::detail::d1::constraints::single_core_type(core_type_index)
+                 ? (size_t)core_type_index
+                 : tbb::detail::log2(core_type_index & ((1 << tbb::detail::d1::constraints::core_type_id_bits) - 1))) <
+                core_types_affinity_masks_list.size(),
+            "Wrong core type id");
         __TBB_ASSERT(max_threads_per_core == -1 || max_threads_per_core > 0, "Wrong max_threads_per_core");
 
         hwloc_cpuset_t constraints_mask = hwloc_bitmap_alloc();
@@ -327,7 +366,18 @@ public:
             hwloc_bitmap_and(constraints_mask, constraints_mask, numa_affinity_masks_list[numa_node_index]);
         }
         if (core_type_index >= 0) {
-            hwloc_bitmap_and(constraints_mask, constraints_mask, core_types_affinity_masks_list[core_type_index]);
+            auto core_types = tbb::detail::d1::constraints{}.set_core_type(core_type_index).get_core_types();
+            __TBB_ASSERT(!core_types.empty(), "Core types list must not be empty");
+
+            hwloc_cpuset_t core_types_mask = hwloc_bitmap_alloc();
+
+            // Combine affinity masks for specified core types
+            for (int c : core_types) {
+                hwloc_bitmap_or(core_types_mask, core_types_mask, core_types_affinity_masks_list[c]);
+            }
+
+            hwloc_bitmap_and(constraints_mask, constraints_mask, core_types_mask);
+            hwloc_bitmap_free(core_types_mask);
         }
         if (max_threads_per_core > 0) {
             // clear input mask

--- a/src/tbbbind/tbb_bind.cpp
+++ b/src/tbbbind/tbb_bind.cpp
@@ -195,15 +195,12 @@ private:
         bool core_types_parsing_broken = core_types_number <= 0;
         if (!core_types_parsing_broken) {
             core_types_affinity_masks_list.resize(core_types_number);
-            int efficiency{-1};
 
             for (int core_type = 0; core_type < core_types_number; ++core_type) {
                 hwloc_cpuset_t& current_mask = core_types_affinity_masks_list[core_type];
                 current_mask = hwloc_bitmap_alloc();
 
-                if (!hwloc_cpukinds_get_info(topology, core_type, current_mask, &efficiency, nullptr, nullptr, 0)
-                    && efficiency >= 0
-                ) {
+                if (!hwloc_cpukinds_get_info(topology, core_type, current_mask, nullptr, nullptr, nullptr, 0)) {
                     hwloc_bitmap_and(current_mask, current_mask, process_cpu_affinity_mask);
 
                     if (hwloc_bitmap_weight(current_mask) > 0) {

--- a/src/tbbbind/tbb_bind.cpp
+++ b/src/tbbbind/tbb_bind.cpp
@@ -216,7 +216,6 @@ private:
                 }
             }
         }
-
         // On hybrid CPUs, check if there are cores without L3 cache.
         if (!core_types_parsing_broken && core_types_number > 1) {
             // The first core type mask (least performant cores)

--- a/src/tbbbind/tbb_bind.rc
+++ b/src/tbbbind/tbb_bind.rc
@@ -1,4 +1,4 @@
-// Copyright (c) 2005-2024 Intel Corporation
+// Copyright (c) 2005-2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright 2005-2024 Intel Corporation.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright 2005-2025 Intel Corporation.  All Rights Reserved.\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbbind.dll\0"

--- a/src/tbbmalloc/tbbmalloc.rc
+++ b/src/tbbmalloc/tbbmalloc.rc
@@ -1,4 +1,4 @@
-// Copyright (c) 2005-2024 Intel Corporation
+// Copyright (c) 2005-2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright 2005-2024 Intel Corporation.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright 2005-2025 Intel Corporation.  All Rights Reserved.\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbmalloc.dll\0"

--- a/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
+++ b/src/tbbmalloc_proxy/tbbmalloc_proxy.rc
@@ -1,4 +1,4 @@
-// Copyright (c) 2005-2024 Intel Corporation
+// Copyright (c) 2005-2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ BEGIN
             VALUE "CompanyName", "Intel Corporation\0"
             VALUE "FileDescription", "oneAPI Threading Building Blocks (oneTBB) library\0"
             VALUE "FileVersion", TBB_VERSION "\0"
-            VALUE "LegalCopyright", "Copyright 2005-2024 Intel Corporation.  All Rights Reserved.\0"
+            VALUE "LegalCopyright", "Copyright 2005-2025 Intel Corporation.  All Rights Reserved.\0"
             VALUE "LegalTrademarks", "\0"
 #ifndef TBB_USE_DEBUG
             VALUE "OriginalFilename", "tbbmalloc_proxy.dll\0"

--- a/test/common/common_arena_constraints.h
+++ b/test/common/common_arena_constraints.h
@@ -228,7 +228,6 @@ private:
             "HWLOC cannot detect the number of cpukinds.(reference)");
 
         core_types_parsing_broken = num_cpu_kinds == 0;
-        int current_efficiency = -1;
         cpu_kind_infos.resize(num_cpu_kinds);
         for (auto kind_index = 0; kind_index < num_cpu_kinds; ++kind_index) {
             auto& cki = cpu_kind_infos[kind_index];
@@ -243,10 +242,6 @@ private:
                 hwloc_cpukinds_get_info, topology, kind_index, cki.cpuset, /*efficiency*/nullptr,
                 /*nr_infos*/nullptr, /*infos*/nullptr, /*flags*/0
             );
-            if (current_efficiency < 0) {
-                core_types_parsing_broken = true;
-                break;
-            }
             hwloc_bitmap_and(cki.cpuset, cki.cpuset, process_cpuset);
 
             cki.index = hwloc_cpukinds_get_by_cpuset(topology, cki.cpuset, /*flags*/0);


### PR DESCRIPTION
### Description 
Add set_core_types API to tbb::task_arena::constraints. Identify L3-less cores as a new, least performant, core type.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
@wangleis @sunxiaoxia2022

### Other information
