### PR TITLE
Custom assertion handler

### DIFF
--- a/include/oneapi/tbb/detail/_assert.h
+++ b/include/oneapi/tbb/detail/_assert.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -32,11 +33,27 @@ namespace r1 {
   Otherwise call the assertion handler. */
 TBB_EXPORT void __TBB_EXPORTED_FUNC assertion_failure(const char *location, int line,
                                                       const char *expression, const char *comment);
+
+using assertion_handler_type = decltype(&assertion_failure);
+
+//! Set assertion handler and return its previous value.
+TBB_EXPORT assertion_handler_type __TBB_EXPORTED_FUNC set_assertion_handler(assertion_handler_type new_handler) noexcept;
+
+//! Return the current assertion handler.
+TBB_EXPORT assertion_handler_type __TBB_EXPORTED_FUNC get_assertion_handler() noexcept;
+
 #if __TBBMALLOC_BUILD
 }} // namespaces rml::internal
 #else
 } // namespace r1
 } // namespace detail
+
+inline namespace v1 {
+using detail::r1::assertion_handler_type;
+using detail::r1::set_assertion_handler;
+using detail::r1::get_assertion_handler;
+} // namespace v1
+
 } // namespace tbb
 #endif
 

--- a/src/tbb/def/lin32-tbb.def
+++ b/src/tbb/def/lin32-tbb.def
@@ -19,6 +19,8 @@ global:
 
 /* Assertions (assert.cpp) */
 _ZN3tbb6detail2r117assertion_failureEPKciS3_S3_;
+_ZN3tbb6detail2r121set_assertion_handlerEPFvPKciS3_S3_E;
+_ZN3tbb6detail2r121get_assertion_handlerEv;
 
 /* ITT (profiling.cpp) */
 _ZN3tbb6detail2r112itt_task_endENS0_2d115itt_domain_enumE;

--- a/src/tbb/def/lin64-tbb.def
+++ b/src/tbb/def/lin64-tbb.def
@@ -19,6 +19,8 @@ global:
 
 /* Assertions (assert.cpp) */
 _ZN3tbb6detail2r117assertion_failureEPKciS3_S3_;
+_ZN3tbb6detail2r121set_assertion_handlerEPFvPKciS3_S3_E;
+_ZN3tbb6detail2r121get_assertion_handlerEv;
 
 /* ITT (profiling.cpp) */
 _ZN3tbb6detail2r112itt_task_endENS0_2d115itt_domain_enumE;

--- a/src/tbb/def/mac64-tbb.def
+++ b/src/tbb/def/mac64-tbb.def
@@ -21,6 +21,8 @@
 
 # Assertions (assert.cpp)
 __ZN3tbb6detail2r117assertion_failureEPKciS3_S3_
+__ZN3tbb6detail2r121set_assertion_handlerEPFvPKciS3_S3_E
+__ZN3tbb6detail2r121get_assertion_handlerEv
 
 # ITT (profiling.cpp)
 __ZN3tbb6detail2r112itt_task_endENS0_2d115itt_domain_enumE

--- a/src/tbb/def/win32-tbb.def
+++ b/src/tbb/def/win32-tbb.def
@@ -18,6 +18,8 @@ EXPORTS
 
 ; Assertions (assert.cpp)
 ?assertion_failure@r1@detail@tbb@@YAXPBDH00@Z
+?set_assertion_handler@r1@detail@tbb@@YAP6AXPBDH00@ZP6AX0H00@Z@Z
+?get_assertion_handler@r1@detail@tbb@@YAP6AXPBDH00@ZXZ
 
 ; ITT (tbb_profiling.cpp)
 ?call_itt_notify@r1@detail@tbb@@YAXHPAX@Z

--- a/src/tbb/def/win64-tbb.def
+++ b/src/tbb/def/win64-tbb.def
@@ -18,6 +18,8 @@ EXPORTS
 
 ; Assertions (assert.cpp)
 ?assertion_failure@r1@detail@tbb@@YAXPEBDH00@Z
+?set_assertion_handler@r1@detail@tbb@@YAP6AXPEBDH00@ZP6AX0H00@Z@Z
+?get_assertion_handler@r1@detail@tbb@@YAP6AXPEBDH00@ZXZ
 
 ; ITT (tbb_profiling.cpp)
 ?call_itt_notify@r1@detail@tbb@@YAXHPEAX@Z

--- a/src/tbbbind/CMakeLists.txt
+++ b/src/tbbbind/CMakeLists.txt
@@ -85,6 +85,7 @@ function(tbbbind_build TBBBIND_NAME REQUIRED_HWLOC_TARGET)
     target_link_libraries(${TBBBIND_NAME}
         PUBLIC
         ${REQUIRED_HWLOC_TARGET}
+        TBB::tbb
         PRIVATE
         ${TBB_LIB_LINK_LIBS}
         ${TBB_COMMON_LINK_LIBS}

--- a/src/tbbbind/tbb_bind.cpp
+++ b/src/tbbbind/tbb_bind.cpp
@@ -1,5 +1,6 @@
 /*
-    Copyright (c) 2019-2024 Intel Corporation
+    Copyright (c) 2019-2025 Intel Corporation
+    Copyright (c) 2025 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -17,7 +18,6 @@
 #include <vector>
 #include <mutex>
 
-#include "../tbb/assert_impl.h" // Out-of-line TBB assertion handling routines are instantiated here.
 #include "oneapi/tbb/detail/_assert.h"
 #include "oneapi/tbb/detail/_config.h"
 


### PR DESCRIPTION
### Description 
Implements #1808 by 
- adding `set_assertion_handler`/`get_assertion_handler` to the API
- modifying TBBBind to use the custom assertion handler through a dependency on the TBB shared library

Fixes #1258.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [x] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [x] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown