### PR TITLE
Do not load TBBbind, only use already loaded

### DIFF
--- a/test/tbb/test_tbbbind.cpp
+++ b/test/tbb/test_tbbbind.cpp
@@ -63,7 +63,9 @@ BindingHandlerType GetDeallocateBindingHandler() {
     for (const auto& tbbbind_version : tbbbind_libraries_list) {
         if (dynamic_link(tbbbind_version, LinkTable,
                          sizeof(LinkTable) / sizeof(dynamic_link_descriptor), nullptr,
-                         DYNAMIC_LINK_LOCAL_BINDING)) {
+                         // use DYNAMIC_LINK_GLOBAL because we must not load TBBbind, we need to
+                         // find already loaded TBBbind to get the symbol from it
+                         DYNAMIC_LINK_GLOBAL)) {
             return deallocate_binding_handler_ptr;
         }
     }


### PR DESCRIPTION
### Description 
The test manually load TBBbind. Previously the test repeated the TBBbind load procedure from TBB library, so potentially the test could load a TBBbind different from one loaded by the TBB library. After the change no new load is performed, only search between already loaded dynamic libraries. This resolves the potential issue mentioned above.

### Type of change

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [X] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
