### PR TITLE
Suppress warning C4611 in MSVC

### DIFF
--- a/test/common/utils_assert.h
+++ b/test/common/utils_assert.h
@@ -56,6 +56,15 @@ void AssertSameType( const T& /*x*/, const T& /*y*/ ) {}
 
 #include "tbb/global_control.h"
 
+ 
+// Suppress warning about setjmp/longjmp usage in C++ in MSVC.
+// It is not guaranteed by the standard that stack-frame objects are destroyed correctly if longjmp is used.
+// But since we use it only in testing and only when exceptions are not possible, it should be acceptable.
+#if _MSC_VER && !TBB_USE_EXCEPTIONS
+#pragma warning(push)
+#pragma warning(disable : 4611)
+#endif
+
 //! Check that expression x raises assertion failure with message containing given substring.
 /** Calls utils::SetCustomAssertionHandler to set utils::AssertionFailureHandler as a handler. */
 #if TBB_USE_EXCEPTIONS
@@ -124,6 +133,10 @@ void AssertionFailureHandler(const char* filename, int line,
     g_assertion_failure.reset(new AssertionFailure(filename, line, expression, comment));
     std::longjmp(g_assertion_jmp_buf, 1);
 }
+#endif
+
+#if _MSC_VER && !TBB_USE_EXCEPTIONS
+#pragma warning(pop)
 #endif
 
 tbb::ext::assertion_handler_type SetCustomAssertionHandler() {

--- a/test/common/utils_assert.h
+++ b/test/common/utils_assert.h
@@ -61,8 +61,7 @@ void AssertSameType( const T& /*x*/, const T& /*y*/ ) {}
 // It is not guaranteed by the standard that stack-frame objects are destroyed correctly if longjmp is used.
 // But since we use it only in testing and only when exceptions are not possible, it should be acceptable.
 #if _MSC_VER && !TBB_USE_EXCEPTIONS
-#pragma warning(push)
-#pragma warning(disable : 4611)
+#pragma warning(disable: 4611)
 #endif
 
 //! Check that expression x raises assertion failure with message containing given substring.
@@ -133,10 +132,6 @@ void AssertionFailureHandler(const char* filename, int line,
     g_assertion_failure.reset(new AssertionFailure(filename, line, expression, comment));
     std::longjmp(g_assertion_jmp_buf, 1);
 }
-#endif
-
-#if _MSC_VER && !TBB_USE_EXCEPTIONS
-#pragma warning(pop)
 #endif
 
 tbb::ext::assertion_handler_type SetCustomAssertionHandler() {


### PR DESCRIPTION
### Description 
Suppress warning about setjmp/longjmp usage in C++ in MSVC.

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
