### PR TITLE
Qnx master

### DIFF
--- a/test/common/memory_usage.h
+++ b/test/common/memory_usage.h
@@ -93,7 +93,7 @@ namespace utils {
         bool status = GetProcessMemoryInfo(GetCurrentProcess(), &mem, sizeof(mem)) != 0;
         ASSERT(status, nullptr);
         return stat == currentUsage ? mem.PagefileUsage : mem.PeakPagefileUsage;
-#elif __unix__
+#elif __unix__ && !defined(__QNX__)
         long unsigned size = 0;
         FILE* fst = fopen("/proc/self/status", "r");
         ASSERT(fst != nullptr, nullptr);

--- a/test/conformance/conformance_resumable_tasks.cpp
+++ b/test/conformance/conformance_resumable_tasks.cpp
@@ -16,7 +16,8 @@
 
 #include "common/test.h"
 
-#if (!__TBB_WIN8UI_SUPPORT && !defined(WINAPI_FAMILY) && !__ANDROID__)
+#if (!__TBB_WIN8UI_SUPPORT && !defined(WINAPI_FAMILY) && !__ANDROID__ \
+    && !__QNX__)
 
 #include "oneapi/tbb/task.h"
 #include "oneapi/tbb/task_group.h"

--- a/test/tbb/test_eh_thread.cpp
+++ b/test/tbb/test_eh_thread.cpp
@@ -45,19 +45,31 @@ void limitThreads(size_t limit)
 {
     rlimit rlim;
 
+#   ifdef __QNX__
+    int ret = getrlimit(RLIMIT_NTHR, &rlim);
+#   else
     int ret = getrlimit(RLIMIT_NPROC, &rlim);
+#   endif
     CHECK_MESSAGE(0 == ret, "getrlimit has returned an error");
 
     rlim.rlim_cur = (rlim.rlim_max == (rlim_t)RLIM_INFINITY) ? limit : utils::min((rlim_t)limit, rlim.rlim_max);
 
+#   ifdef __QNX__
+    ret = setrlimit(RLIMIT_NTHR, &rlim);
+#   else
     ret = setrlimit(RLIMIT_NPROC, &rlim);
+#   endif
     CHECK_MESSAGE(0 == ret, "setrlimit has returned an error");
 }
 
 size_t getThreadLimit() {
     rlimit rlim;
 
+#   ifdef __QNX__
+    int ret = getrlimit(RLIMIT_NTHR, &rlim);
+#   else
     int ret = getrlimit(RLIMIT_NPROC, &rlim);
+#   endif
     CHECK_MESSAGE(0 == ret, "getrlimit has returned an error");
     return rlim.rlim_cur;
 }


### PR DESCRIPTION
### Description 
Fix tests on QNX.

Don't attempt to open "/proc/self/status" which does not exist on QNX.

Disabled resumable task tests, since that functionality is disabled in `include/oneapi/tbb/detail/_config.h` (the `__TBB_RESUMABLE_TASKS`) flag

We have a different flag, `RLIMIT_NTHR`, for the thread resource than the linux setrlimit implementation.
https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/setrlimit.html


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
