### PR TITLE
Update leave_policy/parallel phase-related RFCs

### DIFF
--- a/rfcs/experimental/global_control_fast_leave/README.md
+++ b/rfcs/experimental/global_control_fast_leave/README.md
@@ -41,9 +41,13 @@ providing a global override mechanism.
 This proposal introduces a new `global_control` parameter called `leave_policy` that, when set to "fast",
 would override the default behavior for arenas that are initialized with `leave_policy::automatic`.
 Setting the parameter would not affect arenas that are already initialized or initialized with an
-explicit `leave_policy`. After initialization, the parallel phase API can independently modify the
-arena's leave behavior at runtime, allowing workers to be retained during active parallel phases
-regardless of the initial state set by the global control.
+explicit `leave_policy`. This follows the decision made in the
+[Completely disable new behavior](../parallel_phase_for_task_arena/README.md#completely-disable-new-behavior)
+section of the parallel phase RFC to keep the arena leave policy static for the lifetime of the arena,
+since there are no use cases for dynamic transition between the states yet. 
+After initialization, the parallel phase API can independently modify the arena's leave behavior
+at runtime, allowing workers to be retained during active parallel phases regardless of
+the initial state set by the global control.
 
 ### New Public API
 
@@ -96,7 +100,10 @@ The `leave_policy` parameter would control whether arenas are initialized with a
 | `task_arena::leave_policy::fast` | Workers leave immediately (fast leave enabled) |
 
 When multiple `global_control` objects exist for `leave_policy`, their logical disjunction would be
-used (consistent with the `terminate_on_exception` parameter). This means if any
+used (consistent with the `terminate_on_exception` parameter). For `leave_policy`, the request for
+`fast` is the restrictive one, since it asks the library to give up threads sooner, so it wins over
+the absence of such a request. As more leave policies appear, new strategy of choosing the next
+`leave_policy` can be implemented. At this point, it means that if any
 `global_control(leave_policy, task_arena::leave_policy::fast)` is active, fast leave would be enabled globally.
 
 ### Proposed Implementation Strategy
@@ -327,20 +334,6 @@ The default behavior could be changed to fast leave, making delayed leave opt-in
 
 **Cons:**
 - Fixes performance regression for some customers while causing it for others
-
-## Open Questions
-
-1. **Naming**: Should it convey "default override" semantics?
-   - Current proposal: parameter name matches `task_arena::leave_policy` for consistency
-   - Alternative: e.g., `override_default_leave_policy` to clarify no effect on already initialized arenas
-
-2. **Scope and Granularity**
-   - Current proposal: only affect arenas initialized after the `global_control` is set
-   - Alternative: allow retroactive effect on existing arenas
-   - Alternative: allow per worker control (e.g., via observers) to enable/disable fast leave on a per-thread basis
-
-3. **Composition**: Should the global control be a logical disjunction, first-registered wins, last-set wins, etc.?
-   - Current proposal: disjunction
 
 ## Exit Criteria
 

--- a/rfcs/experimental/global_control_fast_leave/README.md
+++ b/rfcs/experimental/global_control_fast_leave/README.md
@@ -99,12 +99,11 @@ The `leave_policy` parameter would control whether arenas are initialized with a
 | `task_arena::leave_policy::automatic` (default) | Workers follow the default system-specific policy (may spin before leaving) |
 | `task_arena::leave_policy::fast` | Workers leave immediately (fast leave enabled) |
 
-When multiple `global_control` objects exist for `leave_policy`, their logical disjunction is
-used (consistent with the `terminate_on_exception` parameter). For `leave_policy`, the request for
-`fast` is the restrictive one, since `automatic` leaves the choice up to the library, so it wins over
-the absence of such a request. If more leave policies appear, a new strategy of choosing the
-`leave_policy` can be implemented. At this point, it means that if any
-`global_control(leave_policy, task_arena::leave_policy::fast)` is active, fast leave is enabled globally.
+When multiple `global_control` objects request `leave_policy`, the first active
+request for `fast` determines the globally active policy, and it stays in effect until the
+corresponding `global_control` object is destroyed. The effect of any other `leave_policy` requests
+made while it is active is not guaranteed at this point. If more leave policies appear, a new
+strategy of choosing the `leave_policy` can be implemented.
 
 ### Proposed Implementation Strategy
 
@@ -171,7 +170,7 @@ While the feature is in preview state, the
 would need to be extended with documentation for the `global_control::leave_policy` parameter:
 - Add a new section "Global Control Integration" describing the `leave_policy` parameter
 - Update the Synopsis to include the `global_control` header and `leave_policy` parameter
-- Add a description of the parameter semantics and selection rule (logical disjunction)
+- Add a description of the parameter semantics and selection rule
 - Document the interaction between `global_control::leave_policy` and per-arena `leave_policy`
 - Add usage examples showing how to combine global fast leave with parallel phases
 - Include a note explaining that `global_control::leave_policy` provides application-wide control
@@ -236,7 +235,7 @@ int main() {
 }
 ```
 
-#### Global Control Scope, Initialization Order, and Disjunction
+#### Global Control Scope, Initialization Order, and Active Value Selection Rule
 
 ```cpp
 // No global_control is active yet; this call lazily initializes the implicit arena with automatic (the default).
@@ -255,7 +254,7 @@ tbb::parallel_for(0, 1000000, [](int i) { do_parallel_work(i); });
     {
         tbb::global_control gc2(tbb::global_control::leave_policy, tbb::task_arena::leave_policy::automatic);
         tbb::task_arena arena2;
-        // Both gc1 (fast) and gc2 (automatic) are active. Disjunction rule: any fast value present => fast wins.
+        // gc1 (fast) became active first, so it stays in effect; the effect of gc2 is not guaranteed.
         arena2.execute([&] { /* ... */ });
     }
 }
@@ -339,6 +338,4 @@ The default behavior could be changed to fast leave, making delayed leave opt-in
 
 The following conditions need to be met to move the feature from experimental to fully supported:
 - Open questions regarding the API should be resolved.
-- User feedback should confirm usability and performance improvements in mentioned scenarios and that no unforeseen
-  issues arise.
 - The feature must be added to the oneTBB specification and accepted.

--- a/rfcs/experimental/global_control_fast_leave/README.md
+++ b/rfcs/experimental/global_control_fast_leave/README.md
@@ -44,7 +44,7 @@ Setting the parameter would not affect arenas that are already initialized or in
 explicit `leave_policy`. This follows the decision made in the
 [Completely disable new behavior](../parallel_phase_for_task_arena/README.md#completely-disable-new-behavior)
 section of the parallel phase RFC to keep the arena leave policy static for the lifetime of the arena,
-since there are no use cases for dynamic transition between the states yet. 
+since we are not aware of practical use cases for dynamic transition between the states. 
 After initialization, the parallel phase API can independently modify the arena's leave behavior
 at runtime, allowing workers to be retained during active parallel phases regardless of
 the initial state set by the global control.
@@ -99,12 +99,12 @@ The `leave_policy` parameter would control whether arenas are initialized with a
 | `task_arena::leave_policy::automatic` (default) | Workers follow the default system-specific policy (may spin before leaving) |
 | `task_arena::leave_policy::fast` | Workers leave immediately (fast leave enabled) |
 
-When multiple `global_control` objects exist for `leave_policy`, their logical disjunction would be
+When multiple `global_control` objects exist for `leave_policy`, their logical disjunction is
 used (consistent with the `terminate_on_exception` parameter). For `leave_policy`, the request for
-`fast` is the restrictive one, since it asks the library to give up threads sooner, so it wins over
-the absence of such a request. As more leave policies appear, new strategy of choosing the next
+`fast` is the restrictive one, since `automatic` leaves the choice up to the library, so it wins over
+the absence of such a request. If more leave policies appear, a new strategy of choosing the
 `leave_policy` can be implemented. At this point, it means that if any
-`global_control(leave_policy, task_arena::leave_policy::fast)` is active, fast leave would be enabled globally.
+`global_control(leave_policy, task_arena::leave_policy::fast)` is active, fast leave is enabled globally.
 
 ### Proposed Implementation Strategy
 

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -208,7 +208,8 @@ The same use case can be expressed using the `parallel_phase` object, assuming m
 
 ```cpp
 void handle_request(Request req) {
-    tbb::task_arena::parallel_phase phase{tbb::attach{}};
+    tbb::task_arena::parallel_phase phase{tbb::attach{},
+                                          tbb::task_arena::parallel_phase::end_flags::with_fast_leave};
     //
     // Some composition of parallel and serial computations
     //

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -42,12 +42,10 @@ Let’s consider both “Delayed leave” and “Fast leave” as 2 different st
 
 <img src="completely_disable_new_behavior.png" width=800>
 
-There will be a question that we need to answer:
-* Do we see any value if arena potentially can transition from one to another state?
-
-To answer this question, the following scenarios should be considered:
-* What if different types of workloads are mixed in one application?
-* Different types of arenas can be used for different types of workloads.
+The question is whether we should allow the arena to dynamically transition from one state to
+another. At this point, there are no use cases for this, hence the proposal is to keep
+the state static for the lifetime of the arena. If we see a value in the future, the current
+implementation should be flexible enough to support this (see [technical details](#technical-details)).
 
 ### When threads should leave?
 
@@ -123,7 +121,7 @@ Summary of API changes:
 defaulted to "automatic".
 * Add functions to start and end the parallel phase to the `task_arena` class
 and the `this_task_arena` namespace.
-* Add RAII class to map a parallel phase to a code scope.
+* Add a `task_arena::parallel_phase` RAII class to map a parallel phase to a code scope.
 
 ```cpp
 class task_arena {
@@ -148,27 +146,127 @@ class task_arena {
                     priority a_priority = priority::normal,
                     leave_policy a_leave_policy = leave_policy::automatic);
 
-    void start_parallel_phase();
-    void end_parallel_phase(bool with_fast_leave = false);
-
-    class scoped_parallel_phase {
-        scoped_parallel_phase(task_arena& ta, bool with_fast_leave = false);
+    class parallel_phase {
+        enum class end_flags : /* unspecified type */ {
+            with_fast_leave = /* unspecified */
+        };
+        parallel_phase(attach, end_flags e_flags = {});
+        parallel_phase(task_arena& ta, end_flags e_flags = {});
     };
+    
+    void start_parallel_phase();
+    void end_parallel_phase(parallel_phase::end_flags e_flags = {});
 };
 
 namespace this_task_arena {
     void start_parallel_phase();
-    void end_parallel_phase(bool with_fast_leave = false);
+    void end_parallel_phase(task_arena::parallel_phase::end_flags e_flags = {});
 }
 ```
 The _parallel phase_ continues until each previous `start_parallel_phase` call
-to the same arena has a matching `end_parallel_phase` call.<br>
-Let's introduce RAII scoped object that will help to manage the contract.
+to the same arena has a matching `end_parallel_phase` call.
+Let's also introduce RAII object `parallel_phase` that will help to manage the contract.
+Rather than introducing a separate RAII type in the `this_task_arena` namespace,
+`task_arena::parallel_phase` can be constructed with the `tbb::attach` tag to map the phase to
+the implicit arena associated with the calling thread.
+
+Note that `end_parallel_phase` and the `parallel_phase` constructor accept an `end_flags`
+argument rather than a boolean flag even though `end_flags` has a single flag. Since _parallel phase_
+is a high-level hint to the scheduler, it makes sense that other scheduling hints could be tied to
+it as well, so the API is designed to be configurable. A symmetric `start_flags` parameter
+could be added to `start_parallel_phase` in the future if needed.
 
 If the end of the parallel phase is not indicated by the user, it will be done automatically when
 the last public reference is removed from the arena (i.e., task_arena has been destroyed or,
 for an implicitly created arena, the thread that owns it has completed).
 This ensures correctness is preserved (threads will not be retained forever).
+
+Introduction of the explicit functions `start_parallel_phase` and `end_parallel_phase` opens
+a possibility of misuse: either forgetting to pair phase starts with ends, which is not a
+correctness issue per se as described above, or doing more phase ends than starts
+(e.g. by using RAII class interchangeably with explicit calls).
+That raises a question of whether the parallel phase API should be limited only to the RAII style.
+To answer this question, we need to consider the use cases where explicit calls might be more preferable.
+
+One such use case is asynchronous handoff, where the start and the end of a parallel phase happen
+in different scopes, potentially executed on different threads, so there is no single scope
+to attach an RAII guard to:
+```cpp
+void handle_request(Request req) {
+    tbb::this_task_arena::start_parallel_phase();
+    //
+    // Some composition of parallel and serial computations
+    //
+    tbb::this_task_arena::enqueue([req]() {
+        process(req);
+        tbb::this_task_arena::end_parallel_phase(tbb::task_arena::parallel_phase::end_flags::with_fast_leave);
+    });
+}
+```
+
+The same use case can be expressed using the `parallel_phase` object, assuming move construction is supported:
+
+```cpp
+void handle_request(Request req) {
+    tbb::task_arena::parallel_phase phase{tbb::attach{}};
+    //
+    // Some composition of parallel and serial computations
+    //
+    tbb::this_task_arena::enqueue([req, phs = std::move(phase)]() {
+        process(req);
+        // phs destructor will indicate the end of the parallel phase
+    });
+}
+```
+Another use case is a long-lived service where the parallel phase is meant to span multiple,
+unrelated requests and should only end after a period of inactivity, e.g. driven by an idle timer
+rather than the destruction of a scope:
+```cpp
+class Service {
+    tbb::task_arena ta;
+    bool phase_started = false;
+
+    void on_request() {
+        if (!phase_started) {
+            ta.start_parallel_phase();
+            phase_started = true;
+        }
+        ta.execute([]() { /* work */ });
+        reset_idle_timer();
+    }
+
+    void on_idle_timeout() {
+        ta.end_parallel_phase();
+        phase_started = false;
+    }
+};
+```
+This use case can also be expressed using the `parallel_phase` object:
+```cpp
+class Service {
+    tbb::task_arena ta;
+    std::optional<tbb::task_arena::parallel_phase> phase;
+
+    void on_request() {
+        if (!phase) {
+            phase.emplace(ta);
+        }
+        ta.execute([]() { /* work */ });
+        reset_idle_timer();
+    }
+
+    void on_idle_timeout() {
+        phase.reset();
+    }
+};
+```
+If the friction of dealing with the RAII object is considered too high, then it makes sense to provide the explicit functions as well.
+
+The start of _parallel phase_ can also be used as a warm-up hint for the workers to enter
+the arena in advance, therefore the arena (including the implicit arena bound to the external thread)
+must be initialized during the first call to `start_parallel_phase`. It means that if a calling thread has
+no associated arena yet, the invocation of `this_task_arena::start_parallel_phase` will initialize
+an arena and bind it to the calling thread.
 
 ### Examples
 
@@ -200,7 +298,7 @@ void parallel_phase_example() {
     tbb::parallel_for(0, work_size, [] (int idx) {
         // User defined body
     });
-    tbb::this_task_arena::end_parallel_phase(/*with_fast_leave=*/true);
+    tbb::this_task_arena::end_parallel_phase(tbb::task_arena::parallel_phase::end_flags::with_fast_leave);
 
     // Different parallel runtime (for example, OpenMP) is used
     // so it is preferred that worker threads won't be retained
@@ -211,11 +309,12 @@ void parallel_phase_example() {
     }
 }
 
-void scoped_parallel_phase_example() {
+void parallel_phase_raii_example() {
     tbb::task_arena ta{/*arena constraints*/};
     {
         // Start of the parallel phase
-        tbb::task_arena::scoped_parallel_phase phase{ta, /*with_fast_leave=*/true};
+        tbb::task_arena::parallel_phase phase{ta,
+            tbb::task_arena::parallel_phase::end_flags::with_fast_leave};
         ta.execute([]() {
             // Parallel computation
         });
@@ -272,6 +371,8 @@ To implement the proposed feature, the following changes were made:
 Specifically, it controls when worker threads are allowed to be retained in the arena.
 `thread_leave_manager` is initialized with a state that determines the default
 behavior for workers leaving the arena.
+If the dynamic leave policy change is required, new entry points can be added to control the state of
+`thread_leave_manager` at runtime.
 
 To support `start/end_parallel_phase` API, it provides functionality to override the default
 state with a "Parallel Phase" state. It also keeps track of the number of active parallel phases.
@@ -285,18 +386,8 @@ the `thread_leave_manager` during the execution of parallel phases. It shows how
 ## Open Questions in Design
 
 Some open questions that remain:
-* Are the suggested APIs sufficient?
-  * In the current version of proposed API, the `scoped_parallel_phase` object can be created
-    only for already existing `task_arena`. Should it be possible for `this_task_arena` as well?
-  * What should be expected from "Parallel Phase" API for `this_task_arena` when a calling thread
-    doesn't yet have any associated arena?
-  * Should parallel phase API be limited only to RAII-only style?
-    * Are there any scenarios where inconvenience of handling `scoped_parallel_phase` object is
-      not acceptable?
 * Are there additional use cases that should be considered that we missed in our analysis?
-* Do we see any value if arena potentially can transition from one to another state?
-  * What if different types of workloads are mixed in one application?
-  * What if there concurrent calls to this API?
+  So far, no additional use cases have been raised through the RFC review process.
 
 ## Conditions to become fully supported
 

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -6,12 +6,12 @@ In oneTBB, there has never been an API that allows users to block worker threads
 This design choice was made to preserve the composability of the application.
 Before PR#1352, workers moved to the thread pool to sleep once there were no arenas with active
 demand. However, PR#1352 introduced a delayed leave behavior to the library that
-results in blocking threads for an _implementation-defined_ duration inside an arena
+results in blocking threads for an _implementation-specific_ duration inside an arena
 if there is no active demand arcoss all arenas. This change significantly
 improved performance for various applications on high thread count systems.
 The main idea is that usually, after one parallel computation ends,
 another will start after some time. The delayed leave behavior is a heuristic to utilize this,
-covering most cases within _implementation-defined_ duration.
+covering most cases within _implementation-specific_ duration.
 
 However, the new behavior is not the perfect match for all the scenarios:
 * The heuristic of delayed leave is unsuitable for the tasks that are submitted
@@ -44,8 +44,8 @@ Let’s consider both “Delayed leave” and “Fast leave” as 2 different st
 
 One question was whether we should allow the arena to dynamically transition from one state to
 another. Due to the lack of use cases that would justify this, the decision is to keep the state
-static for the lifetime of the arena. The current implementation is flexible enough to support such
-extension (see [technical details](#technical-details)).
+static for the lifetime of the arena. The underlying implementation is already flexible enough
+that dynamic state transitions could be added later without a redesign (see [technical details](#technical-details)).
 
 ### When threads should leave?
 
@@ -147,8 +147,8 @@ class task_arena {
                     leave_policy a_leave_policy = leave_policy::automatic);
 
     class parallel_phase {
-        // Available only when each type in Flags is a parallel phase flag
         class flags {
+            // Available only when each type in Flags is a parallel phase flag
             template <typename... Flags>
             flags(Flags... f);
         };
@@ -186,7 +186,9 @@ namespace this_task_arena {
     task_arena::parallel_phase create_parallel_phase(task_arena::parallel_phase::flags f = {});
 }
 ```
-The factory function approach seems more consistent with the rest of task arena API.
+The factory function approach might seem more consistent with the rest of task arena API.
+As there are no clear advantages of factory function, the proposal is to stick to the constructor approach
+since it is an already established pattern of the feature during experimental stage.
 
 #### Flags
 
@@ -210,19 +212,19 @@ must be initialized during the first call to `start_parallel_phase`. It means th
 no associated arena yet, the invocation of `this_task_arena::start_parallel_phase` will initialize
 an arena and bind it to the calling thread.
 
-If the end of the parallel phase is not indicated by the user, it will be done automatically when
-the last public reference is removed from the arena (i.e., task_arena has been destroyed or,
-for an implicitly created arena, the thread that owns it has completed).
-This ensures correctness is preserved (threads will not be retained forever).
+The arena lifetime must not end while a parallel phase is still active. It is the user's
+responsibility to call `end_parallel_phase` for every outstanding `start_parallel_phase` 
+(or destroy the corresponding `parallel_phase` object) before the arena is destroyed (or, for an implicitly
+created arena, before the owning thread completes). Otherwise, the behavior is undefined.
 
 #### RAII vs explicit calls
 
 Introduction of the explicit functions `start_parallel_phase` and `end_parallel_phase` opens
-a possibility of misuse: either forgetting to pair phase starts with ends, which is not a
-correctness issue per se as described above, or doing more phase ends than starts
+a possibility of misuse: either forgetting to pair phase starts with ends, which results in
+undefined behavior as described above, or doing more phase ends than starts
 (e.g. by using RAII class interchangeably with explicit calls).
 That raises a question of whether the parallel phase API should be limited only to the RAII style.
-To answer this question, we need to consider the use cases where explicit calls might be more preferable.
+To answer this question, we considered the use cases where explicit calls are more preferable.
 
 One such use case is asynchronous handoff, where the start and the end of a parallel phase happen
 in different scopes, potentially executed on different threads, so there is no single scope
@@ -247,9 +249,6 @@ The same use case can be expressed using the `parallel_phase` object, assuming m
 void handle_request(Request req) {
     tbb::task_arena::parallel_phase phase{tbb::attach{},
                                           tbb::task_arena::parallel_phase::end_with_fast_leave{}};
-    // or
-    // auto phase = tbb::this_task_arena::create_parallel_phase(tbb::task_arena::parallel_phase::end_with_fast_leave{});
-    //
     // Some composition of parallel and serial computations
     //
     tbb::this_task_arena::enqueue([req, phs = std::move(phase)]() {
@@ -290,8 +289,6 @@ class Service {
     void on_request() {
         if (!phase) {
             phase = std::make_unique<tbb::task_arena::parallel_phase>(ta);
-            // or
-            // phase = std::make_unique<tbb::task_arena::parallel_phase>(ta.create_parallel_phase());
         }
         ta.execute([]() { /* work */ });
         reset_idle_timer();
@@ -302,7 +299,9 @@ class Service {
     }
 };
 ```
-If the friction of dealing with the RAII object is considered too high, then it makes sense to provide the explicit functions as well.
+The friction of dealing with the RAII object in these cases can be considered too high, so the decision
+is to provide the explicit `start_parallel_phase`/`end_parallel_phase` functions in addition to the
+RAII `parallel_phase` class.
 
 ### Examples
 

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -155,6 +155,8 @@ class task_arena {
         class end_with_fast_leave;
         parallel_phase(attach, flags f = {});
         parallel_phase(task_arena& ta, flags f = {});
+        parallel_phase(parallel_phase&& other);
+        parallel_phase& operator=(parallel_phase&& other);
         void end();
     };
     
@@ -190,6 +192,11 @@ The factory function approach might seem more consistent with the rest of task a
 As there are no clear advantages of factory function, the proposal is to stick to the constructor approach
 since it is an already established pattern of the feature during experimental stage.
 
+The RAII object is move-constructible and move-assignable, but not copyable. For a `parallel_phase`
+bound to an explicit arena, the requirement is that the arena itself must not be destroyed
+while the phase is still active. A `parallel_phase` created with `tbb::attach` is bound to the
+implicit arena of the creating thread, so it must not end outside of that same implicit arena.
+
 #### Flags
 
 Note that all the entry points accept a single `parallel_phase::flags` argument rather than a
@@ -212,8 +219,8 @@ must be initialized during the first call to `start_parallel_phase`. It means th
 no associated arena yet, the invocation of `this_task_arena::start_parallel_phase` will initialize
 an arena and bind it to the calling thread.
 
-The arena lifetime must not end while a parallel phase is still active. It is the user's
-responsibility to call `end_parallel_phase` for every outstanding `start_parallel_phase` 
+As mentioned above, the arena lifetime must not end while a parallel phase is still active.
+It is the user's responsibility to call `end_parallel_phase` for every outstanding `start_parallel_phase`
 (or destroy the corresponding `parallel_phase` object) before the arena is destroyed (or, for an implicitly
 created arena, before the owning thread completes). Otherwise, the behavior is undefined.
 
@@ -243,7 +250,7 @@ void handle_request(Request req) {
 }
 ```
 
-The same use case can be expressed using the `parallel_phase` object, assuming move construction is supported:
+The same use case can be expressed using the `parallel_phase` object:
 
 ```cpp
 void handle_request(Request req) {

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -183,7 +183,7 @@ namespace this_task_arena {
     task_arena::parallel_phase create_parallel_phase(task_arena::parallel_phase::flags f = {});
 }
 ```
-The approach is more consistent with the rest of task arena API.
+The factory function approach seems more consistent with the rest of task arena API.
 
 Note that all the entry points accept a single `parallel_phase::flags` argument rather than a
 boolean flag, even though only one flag is defined for now. Since _parallel phase_ is a high-level

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -42,10 +42,10 @@ Let’s consider both “Delayed leave” and “Fast leave” as 2 different st
 
 <img src="completely_disable_new_behavior.png" width=800>
 
-The question is whether we should allow the arena to dynamically transition from one state to
-another. At this point, there are no use cases for this, hence the proposal is to keep
-the state static for the lifetime of the arena. If we see a value in the future, the current
-implementation should be flexible enough to support this (see [technical details](#technical-details)).
+One question was whether we should allow the arena to dynamically transition from one state to
+another. Due to the lack of use cases that would justify this, the decision is to keep the state
+static for the lifetime of the arena. The current implementation is flexible enough to support such
+extension (see [technical details](#technical-details)).
 
 ### When threads should leave?
 
@@ -169,6 +169,9 @@ namespace this_task_arena {
 ```
 The _parallel phase_ continues until each previous `start_parallel_phase` call
 to the same arena has a matching `end_parallel_phase` call.
+
+#### Using RAII to manage parallel phase
+
 Let's also introduce an RAII object `parallel_phase` that will help to manage the contract.
 Rather than introducing a separate RAII type in the `this_task_arena` namespace,
 `task_arena::parallel_phase` can be constructed with the `tbb::attach` tag to map the phase to
@@ -185,6 +188,8 @@ namespace this_task_arena {
 ```
 The factory function approach seems more consistent with the rest of task arena API.
 
+#### Flags
+
 Note that all the entry points accept a single `parallel_phase::flags` argument rather than a
 boolean flag, even though only one flag is defined for now. Since _parallel phase_ is a high-level
 hint to the scheduler, it makes sense that other scheduling hints could be tied to it as well, so
@@ -197,10 +202,20 @@ for both boundaries at once and applies each of them at the corresponding point,
 functions only take into account the flags applicable to them. A flag passed to an operation it
 does not apply to is ignored. 
 
+#### Starting and ending a parallel phase
+
+The start of _parallel phase_ can also be used as a warm-up hint for the workers to enter
+the arena in advance, therefore the arena (including the implicit arena bound to the external thread)
+must be initialized during the first call to `start_parallel_phase`. It means that if a calling thread has
+no associated arena yet, the invocation of `this_task_arena::start_parallel_phase` will initialize
+an arena and bind it to the calling thread.
+
 If the end of the parallel phase is not indicated by the user, it will be done automatically when
 the last public reference is removed from the arena (i.e., task_arena has been destroyed or,
 for an implicitly created arena, the thread that owns it has completed).
 This ensures correctness is preserved (threads will not be retained forever).
+
+#### RAII vs explicit calls
 
 Introduction of the explicit functions `start_parallel_phase` and `end_parallel_phase` opens
 a possibility of misuse: either forgetting to pair phase starts with ends, which is not a
@@ -288,12 +303,6 @@ class Service {
 };
 ```
 If the friction of dealing with the RAII object is considered too high, then it makes sense to provide the explicit functions as well.
-
-The start of _parallel phase_ can also be used as a warm-up hint for the workers to enter
-the arena in advance, therefore the arena (including the implicit arena bound to the external thread)
-must be initialized during the first call to `start_parallel_phase`. It means that if a calling thread has
-no associated arena yet, the invocation of `this_task_arena::start_parallel_phase` will initialize
-an arena and bind it to the calling thread.
 
 ### Examples
 
@@ -411,15 +420,22 @@ the `thread_leave_manager` during the execution of parallel phases. It shows how
 
 <img src="parallel_phase_sequence_diagram.png" width=1000>
 
-## Open Questions in Design
+## Performance testing
 
-Some open questions that remain:
-* Are there additional use cases that should be considered that we missed in our analysis?
-  So far, no additional use cases have been raised through the RFC review process.
+The [seismic example](../../../examples/parallel_for/seismic) can be a good candidate for measuring
+the impact of _parallel phase_, since each frame invokes two `parallel_for` loops in sequence
+(stress update, then velocity update), so worker threads may leave the arena prematurely
+between updates or between frames instead of staying resident for the whole simulation.
+Wrapping the per-frame loops with `start/end_parallel_phase` should retain workers across frames
+and thus reduce the arena join/leave overhead.
+
+The example can also showcase the `end_with_fast_leave` flag: if one of the two per-frame loops
+were rewritten with a different runtime (e.g. OpenMP), calling `end_parallel_phase` with
+`end_with_fast_leave` before that loop would release oneTBB workers promptly, avoiding
+oversubscription/interference with the OpenMP threads.
 
 ## Conditions to become fully supported
 
 Following conditions need to be met for the feature to move from experimental to fully supported:
 * Open questions regarding API should be resolved.
-* The feature should demonstrate performance improvements in scenarios mentioned.
 * oneTBB specification needs to be updated to reflect the new feature.

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -147,20 +147,24 @@ class task_arena {
                     leave_policy a_leave_policy = leave_policy::automatic);
 
     class parallel_phase {
-        enum class end_flags : /* unspecified type */ {
-            with_fast_leave = /* unspecified */
+        // Available only when each type in Flags is a parallel phase flag
+        class flags {
+            template <typename... Flags>
+            flags(Flags... f);
         };
-        parallel_phase(attach, end_flags e_flags = {});
-        parallel_phase(task_arena& ta, end_flags e_flags = {});
+        class end_with_fast_leave;
+        parallel_phase(attach, flags f = {});
+        parallel_phase(task_arena& ta, flags f = {});
+        void end();
     };
     
-    void start_parallel_phase();
-    void end_parallel_phase(parallel_phase::end_flags e_flags = {});
+    void start_parallel_phase(parallel_phase::flags f = {});
+    void end_parallel_phase(parallel_phase::flags f = {});
 };
 
 namespace this_task_arena {
-    void start_parallel_phase();
-    void end_parallel_phase(task_arena::parallel_phase::end_flags e_flags = {});
+    void start_parallel_phase(task_arena::parallel_phase::flags f = {});
+    void end_parallel_phase(task_arena::parallel_phase::flags f = {});
 }
 ```
 The _parallel phase_ continues until each previous `start_parallel_phase` call
@@ -168,13 +172,30 @@ to the same arena has a matching `end_parallel_phase` call.
 Let's also introduce RAII object `parallel_phase` that will help to manage the contract.
 Rather than introducing a separate RAII type in the `this_task_arena` namespace,
 `task_arena::parallel_phase` can be constructed with the `tbb::attach` tag to map the phase to
-the implicit arena associated with the calling thread.
+the implicit arena associated with the calling thread. The alternative would be, instead of
+passing `tbb::attach`, to have a factory function that returns a `pararlel_phase` object:
+```cpp
+class task_arena {
+    parallel_phase create_parallel_phase(parallel_phase::flags f = {});
+};
 
-Note that `end_parallel_phase` and the `parallel_phase` constructor accept an `end_flags`
-argument rather than a boolean flag even though `end_flags` has a single flag. Since _parallel phase_
-is a high-level hint to the scheduler, it makes sense that other scheduling hints could be tied to
-it as well, so the API is designed to be configurable. A symmetric `start_flags` parameter
-could be added to `start_parallel_phase` in the future if needed.
+namespace this_task_arena {
+    task_arena::parallel_phase create_parallel_phase(task_arena::parallel_phase::flags f = {});
+}
+```
+The approach is more consistent with the rest of task arena API.
+
+Note that all the entry points accept a single `parallel_phase::flags` argument rather than a
+boolean flag, even though only one flag is defined for now. Since _parallel phase_ is a high-level
+hint to the scheduler, it makes sense that other scheduling hints could be tied to it as well, so
+the API is designed to be configurable. Each flag is a distinct tag type, and several of them can
+be combined into a single `flags` object.
+
+Some flags are only applicable to the start of a parallel phase, and others only to its end, which
+can be reflected in their names (e.g. `end_with_fast_leave`). The `parallel_phase` object accepts flags
+for both boundaries at once and applies each of them at the corresponding point, while the explicit
+functions only take into account the flags applicable to them. A flag passed to an operation it
+does not apply to is ignored. 
 
 If the end of the parallel phase is not indicated by the user, it will be done automatically when
 the last public reference is removed from the arena (i.e., task_arena has been destroyed or,
@@ -199,7 +220,8 @@ void handle_request(Request req) {
     //
     tbb::this_task_arena::enqueue([req]() {
         process(req);
-        tbb::this_task_arena::end_parallel_phase(tbb::task_arena::parallel_phase::end_flags::with_fast_leave);
+        tbb::this_task_arena::end_parallel_phase(
+            tbb::task_arena::parallel_phase::end_with_fast_leave{});
     });
 }
 ```
@@ -209,7 +231,9 @@ The same use case can be expressed using the `parallel_phase` object, assuming m
 ```cpp
 void handle_request(Request req) {
     tbb::task_arena::parallel_phase phase{tbb::attach{},
-                                          tbb::task_arena::parallel_phase::end_flags::with_fast_leave};
+                                          tbb::task_arena::parallel_phase::end_with_fast_leave{}};
+    // or
+    // auto phase = tbb::this_task_arena::create_parallel_phase(tbb::task_arena::parallel_phase::end_with_fast_leave{});
     //
     // Some composition of parallel and serial computations
     //
@@ -246,11 +270,13 @@ This use case can also be expressed using the `parallel_phase` object:
 ```cpp
 class Service {
     tbb::task_arena ta;
-    std::optional<tbb::task_arena::parallel_phase> phase;
+    std::unique_ptr<tbb::task_arena::parallel_phase> phase;
 
     void on_request() {
         if (!phase) {
-            phase.emplace(ta);
+            phase = std::make_unique<tbb::task_arena::parallel_phase>(ta);
+            // or
+            // phase = std::make_unique<tbb::task_arena::parallel_phase>(ta.create_parallel_phase());
         }
         ta.execute([]() { /* work */ });
         reset_idle_timer();
@@ -299,7 +325,8 @@ void parallel_phase_example() {
     tbb::parallel_for(0, work_size, [] (int idx) {
         // User defined body
     });
-    tbb::this_task_arena::end_parallel_phase(tbb::task_arena::parallel_phase::end_flags::with_fast_leave);
+    tbb::this_task_arena::end_parallel_phase(
+        tbb::task_arena::parallel_phase::end_with_fast_leave{});
 
     // Different parallel runtime (for example, OpenMP) is used
     // so it is preferred that worker threads won't be retained
@@ -315,7 +342,7 @@ void parallel_phase_raii_example() {
     {
         // Start of the parallel phase
         tbb::task_arena::parallel_phase phase{ta,
-            tbb::task_arena::parallel_phase::end_flags::with_fast_leave};
+            tbb::task_arena::parallel_phase::end_with_fast_leave{}};
         ta.execute([]() {
             // Parallel computation
         });

--- a/rfcs/experimental/parallel_phase_for_task_arena/README.md
+++ b/rfcs/experimental/parallel_phase_for_task_arena/README.md
@@ -169,7 +169,7 @@ namespace this_task_arena {
 ```
 The _parallel phase_ continues until each previous `start_parallel_phase` call
 to the same arena has a matching `end_parallel_phase` call.
-Let's also introduce RAII object `parallel_phase` that will help to manage the contract.
+Let's also introduce an RAII object `parallel_phase` that will help to manage the contract.
 Rather than introducing a separate RAII type in the `this_task_arena` namespace,
 `task_arena::parallel_phase` can be constructed with the `tbb::attach` tag to map the phase to
 the implicit arena associated with the calling thread. The alternative would be, instead of


### PR DESCRIPTION
Updated the RFCs with new API considerations and elaborating open questions in more details.
Note, that ideas proposed in new changes for `parallel_phase` RFC are not final - some of them suggested more confidently, while some should be discussed during the review.