### PR TITLE
Fix lost wakeup in `notify_by_address` on AArch64: `mutex`/`rw_mutex` waiters sleep forever on an already-satisfied predicate

### DIFF
--- a/include/oneapi/tbb/mutex.h
+++ b/include/oneapi/tbb/mutex.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2021-2023 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -74,6 +75,11 @@ public:
         // We need Write Read memory barrier before notify that reads the waiter list.
         // In C++ only full fence covers this type of barrier.
         my_flag.exchange(false);
+#if !(__TBB_x86_64 || __TBB_x86_32)
+        // RMW on x86 works as a full fence,
+        // but on other platforms we need to issue a seq_cst fence explicitly
+        atomic_fence_seq_cst();
+#endif
         my_flag.notify_one_relaxed();
     }
 

--- a/include/oneapi/tbb/rw_mutex.h
+++ b/include/oneapi/tbb/rw_mutex.h
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2021 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -88,11 +89,11 @@ public:
         state_type curr_state = (m_state &= READERS | WRITER_PENDING); // Returns current state
 
         if (curr_state & WRITER_PENDING) {
-            r1::notify_by_address(this, WRITER_CONTEXT);
+            notify(WRITER_CONTEXT);
         } else {
             // It's possible that WRITER sleeps without WRITER_PENDING,
             // because other thread might clear this bit at upgrade()
-            r1::notify_by_address_all(this);
+            notify_all();
         }
     }
 
@@ -116,7 +117,7 @@ public:
         if (!(m_state.load(std::memory_order_relaxed) & has_writer)) {
             if (m_state.fetch_add(ONE_READER) & has_writer) {
                 m_state -= ONE_READER;
-                r1::notify_by_address(this, WRITER_CONTEXT);
+                notify(WRITER_CONTEXT);
             } else {
                 call_itt_notify(acquired, this);
                 return true; // successfully stored increased number of readers
@@ -133,11 +134,11 @@ public:
         state_type curr_state = (m_state -= ONE_READER); // Returns current state
 
         if (curr_state & (WRITER_PENDING)) {
-            r1::notify_by_address(this, WRITER_CONTEXT);
+            notify(WRITER_CONTEXT);
         } else {
             // It's possible that WRITER sleeps without WRITER_PENDING,
             // because other thread might clear this bit at upgrade()
-            r1::notify_by_address_all(this);
+            notify_all();
         }
     }
 
@@ -180,10 +181,32 @@ private:
         m_state += (ONE_READER - WRITER);
 
         if (!(m_state & WRITER_PENDING)) {
-            r1::notify_by_address(this, READER_CONTEXT);
+            notify(READER_CONTEXT);
         }
 
         __TBB_ASSERT(m_state.load(std::memory_order_relaxed) & READERS, "invalid state after downgrade: no readers");
+    }
+
+    using context_type = std::uintptr_t;
+
+    //! Notify waiting threads with the given context
+    void notify(context_type target_context) {
+#if !(__TBB_x86_64 || __TBB_x86_32)
+        // RMW on x86 works as a full fence,
+        // but on other platforms we need to issue a seq_cst fence explicitly
+        atomic_fence_seq_cst();
+#endif
+        r1::notify_by_address(this, target_context);
+    }
+
+    //! Notify all waiting threads
+    void notify_all() {
+#if !(__TBB_x86_64 || __TBB_x86_32)
+        // RMW on x86 works as a full fence,
+        // but on other platforms we need to issue a seq_cst fence explicitly
+        atomic_fence_seq_cst();
+#endif
+        r1::notify_by_address_all(this);
     }
 
     using state_type = std::intptr_t;
@@ -193,7 +216,6 @@ private:
     static constexpr state_type ONE_READER = 4;
     static constexpr state_type BUSY = WRITER | READERS;
 
-    using context_type = std::uintptr_t;
     static constexpr context_type WRITER_CONTEXT = 0;
     static constexpr context_type READER_CONTEXT = 1;
     friend scoped_lock;

--- a/src/tbb/address_waiter.cpp
+++ b/src/tbb/address_waiter.cpp
@@ -72,23 +72,6 @@ void wait_on_address(void* address, d1::delegate_base& predicate, std::uintptr_t
 }
 
 void notify_by_address(void* address, std::uintptr_t target_context) {
-    // The concurrent_monitor protocol requires a full fence between the store that satisfies
-    // a waiter's predicate and the (relaxed) read of the waitset inside notify_*_relaxed():
-    // the waiter side issues one at the end of prepare_wait() ("Prepare wait guarantees
-    // Write Read memory barrier"), and the notifier side must match it, as the non-relaxed
-    // concurrent_monitor::notify_one()/notify_all() do.
-    // The notify_by_address entry points are called by d1::mutex::unlock(),
-    // d1::rw_mutex::unlock(), and waitable_atomic, which only perform an atomic RMW on the
-    // waited address before calling here. An RMW operation is not a two-sided fence: on
-    // architectures with weak memory ordering (e.g. AArch64), the subsequent relaxed
-    // my_waitset.empty() check may read a stale (empty) value before a concurrent waiter's
-    // insertion becomes visible, while that waiter's predicate re-check read the pre-RMW
-    // state. Both threads then observe the old values (store-buffer pattern), the notifier
-    // takes the empty() early exit, and the wakeup is lost: the waiter sleeps forever on an
-    // already-satisfied predicate (e.g. a writer blocked on a free rw_mutex).
-    // Issue the fence here, on the notifier side, to restore the protocol.
-    atomic_fence_seq_cst();
-
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address, target_context] (address_context ctx) {
@@ -99,9 +82,6 @@ void notify_by_address(void* address, std::uintptr_t target_context) {
 }
 
 void notify_by_address_one(void* address) {
-    // See the comment in notify_by_address about the memory ordering requirements.
-    atomic_fence_seq_cst();
-
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address] (address_context ctx) {
@@ -112,9 +92,6 @@ void notify_by_address_one(void* address) {
 }
 
 void notify_by_address_all(void* address) {
-    // See the comment in notify_by_address about the memory ordering requirements.
-    atomic_fence_seq_cst();
-
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address] (address_context ctx) {

--- a/src/tbb/address_waiter.cpp
+++ b/src/tbb/address_waiter.cpp
@@ -72,6 +72,23 @@ void wait_on_address(void* address, d1::delegate_base& predicate, std::uintptr_t
 }
 
 void notify_by_address(void* address, std::uintptr_t target_context) {
+    // The concurrent_monitor protocol requires a full fence between the store that satisfies
+    // a waiter's predicate and the (relaxed) read of the waitset inside notify_*_relaxed():
+    // the waiter side issues one at the end of prepare_wait() ("Prepare wait guarantees
+    // Write Read memory barrier"), and the notifier side must match it, as the non-relaxed
+    // concurrent_monitor::notify_one()/notify_all() do.
+    // The notify_by_address entry points are called by d1::mutex::unlock(),
+    // d1::rw_mutex::unlock(), and waitable_atomic, which only perform an atomic RMW on the
+    // waited address before calling here. An RMW operation is not a two-sided fence: on
+    // architectures with weak memory ordering (e.g. AArch64), the subsequent relaxed
+    // my_waitset.empty() check may read a stale (empty) value before a concurrent waiter's
+    // insertion becomes visible, while that waiter's predicate re-check read the pre-RMW
+    // state. Both threads then observe the old values (store-buffer pattern), the notifier
+    // takes the empty() early exit, and the wakeup is lost: the waiter sleeps forever on an
+    // already-satisfied predicate (e.g. a writer blocked on a free rw_mutex).
+    // Issue the fence here, on the notifier side, to restore the protocol.
+    atomic_fence_seq_cst();
+
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address, target_context] (address_context ctx) {
@@ -82,6 +99,9 @@ void notify_by_address(void* address, std::uintptr_t target_context) {
 }
 
 void notify_by_address_one(void* address) {
+    // See the comment in notify_by_address about the memory ordering requirements.
+    atomic_fence_seq_cst();
+
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address] (address_context ctx) {
@@ -92,6 +112,9 @@ void notify_by_address_one(void* address) {
 }
 
 void notify_by_address_all(void* address) {
+    // See the comment in notify_by_address about the memory ordering requirements.
+    atomic_fence_seq_cst();
+
     address_waiter& waiter = get_address_waiter(address);
 
     auto predicate = [address] (address_context ctx) {


### PR DESCRIPTION
This patch and the notes were generated by Claude based on a locally reproduced deadlock. This is not my area of expertise, but the evidence is clear, and the fix is straightforward. However, I'm not quite sure that `notify_by_address` is the right place to put the fence, so please review carefully.

## Summary

`tbb::detail::r1::notify_by_address*` call the `*_relaxed` notify variants of `concurrent_monitor` without issuing the full memory fence that the monitor's wakeup protocol requires on the notifier side. Their callers (`d1::mutex::unlock`, `d1::rw_mutex::unlock`, `d1::waitable_atomic`) only perform an atomic RMW on the waited address before calling them, and an atomic RMW is not a two-sided fence. On weakly-ordered architectures (AArch64) this permits the classic store-buffer outcome: the notifier's unfenced `my_waitset.empty()` early-exit check reads a stale "empty" waitset while the waiter's predicate re-check read the stale pre-unlock state. The notification is skipped, and the waiter sleeps forever on a mutex that is actually free.

We hit this in production on AWS Graviton 3 (random, unrecoverable process hangs after hours/days of load) and captured a live hung process whose memory state proves the mechanism end-to-end (full forensic evidence below). x86-64 is unaffected because TSO makes the RMW-then-load sequence behave as if fenced — consistent with this class of hang being reported on ARM only.

Affected: oneTBB 2021.13.x (including the `2021.13-ov` branch bundled with OpenVINO) through current mainline — `src/tbb/address_waiter.cpp`, `src/tbb/concurrent_monitor.h`, `include/oneapi/tbb/mutex.h`, and `include/oneapi/tbb/rw_mutex.h` are functionally unchanged from v2021.13.0 through v2023.1.0.

## Environment

- oneTBB 2021.13.0 (`libtbb.so.12.13`, prebuilt `oneapi-tbb-2021.13.0-lin-arm64` bundled with OpenVINO 2025.2)
- Linux aarch64: AWS Graviton 3 (64 cores, production) and a 10-core Apple M1 in Docker (reproduction)
- Workload: OpenVINO CPU inference (`ov::InferRequest::infer` → `CPUStreamsExecutor::execute`) called from a multithreaded host application; the deadlocked path itself is generic TBB scheduler code, not OpenVINO-specific

## Symptom

The process hangs permanently. All-thread stacks show three groups:

1. **One thread spinning** (100% CPU, `sched_yield` loop) inside the task dispatcher's stealing/wait loop, waiting for a nested parallel region to complete:

   ```
   #0 __sched_yield
   #1 libtbb.so.12.13   (task dispatcher wait/steal loop)
   #2 …openvino arm cpu plugin kernels…
   #14 libtbb.so.12.13  (task_arena wait/execute)
   #15 ov::threading::CPUStreamsExecutor::execute(std::function<void()>)
   #18 ov::IAsyncInferRequest::infer()
   ```

2. **One TBB worker blocked *inside* `spawn`** — this is the anomaly:

   ```
   #0 syscall (futex FUTEX_WAIT_PRIVATE, val=2)
   #1 tbb::detail::r1::wait_on_address(void*, delegate_base&, unsigned long) +0x390
   #2 libtbb +0x1e1d4   \
   #3 libtbb +0x1e220    > market::adjust_demand → d1::rw_mutex::lock (writer)
   #4 libtbb +0x1e998   /
   #5 tbb::detail::r1::spawn(task&, task_group_context&, unsigned short) +0x134
   #6 …caller in a parallel region…
   ```

   i.e. `spawn → arena::advertise_new_work` → `arena::request_workers` → `threading_control::adjust_demand` → `market::adjust_demand`, blocked acquiring `market::my_mutex` (a `d1::rw_mutex`) as a **writer**.

3. **All other TBB workers idle**, parked on their per-thread semaphores (`FUTEX_WAIT_PRIVATE`, val=2).

Because the blocked worker never finishes its in-flight task, the nested region's `wait_context` never completes, the spinning thread waits forever, and nothing ever wakes the idle workers (the code that would request/wake them is exactly the code that is blocked).

## Forensic evidence from the live hung process

All values read from `/proc/<pid>/mem` without perturbing the process:

**The rw_mutex the worker is waiting for** (`market::my_mutex`, identified by the containing object's vtable + member offset):

```
m_state = 0x2        // == WRITER_PENDING only; WRITER clear, no READERS
                     // => the mutex is FREE and the writer's wakeup condition
                     //    !(m_state & BUSY) is TRUE right now
```

**The waiter's `sleep_node<address_context>`** (on the blocked worker's stack; layout matches the source exactly):

```
next            = 0x…e4d8f0   // -> address_waiter_table bucket sentinel
prev            = 0x…e4d8f0   // -> same; node is linked, sole element
my_address      = &market::my_mutex
my_context      = 0           // WRITER_CONTEXT
my_initialized  = 1
my_is_in_list   = 1           // never cleared by any notify
my_epoch        = 0x2235
futex word      = 2           // committed, sleeping
```

**The `address_waiter_table` bucket** for that address:

```
sentinel.next = sentinel.prev = &node   // waiter visibly linked, both directions
my_epoch      = 0x2235                  // == node.my_epoch
```

The bucket epoch equals the node epoch. Every notify that enters the locked region increments the epoch (`notify`, `notify_one_relaxed`, `abort_all_relaxed` all do `my_epoch.store(my_epoch.load()+1)` under `my_mutex`), so **no notification ever entered the locked region after this waiter's `prepare_wait`** — despite the fact that `rw_mutex::unlock` is guaranteed to have called `notify_by_address(this, WRITER_CONTEXT)`: the current `m_state` still has `WRITER_PENDING` set, and unlock reads the state *after* its RMW (`curr_state = (m_state &= READERS | WRITER_PENDING)`), so it observed `WRITER_PENDING` and took the notify branch. The only way to reconcile this with the bucket state is the unfenced `my_waitset.empty()` early exit in `notify_relaxed` reading a stale (empty) list head.

## Root cause

The monitor protocol requires a full fence on **both** sides of the wait/notify handshake, and the code documents this:

- Waiter side — `concurrent_monitor.h`, end of `prepare_wait()`:

  ```cpp
  // Prepare wait guarantees Write Read memory barrier.
  // In C++ only full fence covers this type of barrier.
  atomic_fence_seq_cst();
  ```

- Notifier side — the non-relaxed variants do issue it:

  ```cpp
  void notify_one() {
      atomic_fence_seq_cst();
      notify_one_relaxed();
  }
  ```

- But `notify_by_address` / `notify_by_address_one` / `notify_by_address_all` call the `*_relaxed` variants with **no fence**, and their callers only perform an atomic RMW on the waited address. `mutex.h` even states the requirement:

  ```cpp
  // We need Write Read memory barrier before notify that reads the waiter list.
  // In C++ only full fence covers this type of barrier.
  my_flag.exchange(false);      // an RMW — not a fence
  my_flag.notify_one_relaxed();
  ```

An atomic RMW operation is not equivalent to `atomic_thread_fence(seq_cst)` for *independent* subsequent loads. On AArch64 with LL/SC lowering (`ldaxr`/`stlxr`), a later relaxed load of an unrelated address may be satisfied between the exclusive pair — i.e. before the RMW's store is globally visible; formally, the C++ memory model also does not forbid the outcome, as the two RMWs are on different objects and create no synchronizes-with edge with the relaxed loads. The resulting store-buffer interleaving:

```
waiter (rw_mutex::lock)                notifier (rw_mutex::unlock)
--------------------------------       -----------------------------------
insert node into waitset               m_state RMW (frees mutex, sees PENDING)
atomic_fence_seq_cst()                 my_waitset.empty() -> stale "empty"
re-check predicate -> stale BUSY       return, nobody woken
commit sleep (forever)
```

Both threads read the old values; the wakeup is lost. On x86-64 the locked RMW is a full barrier, the stale `empty()` read is impossible, and the bug cannot occur — matching field reports (ARM-only hangs).

Disassembly confirms the shipped aarch64 binaries contain **no `dmb` instruction** anywhere in the `notify_by_address*` entry paths.

## Fix

Issue `atomic_fence_seq_cst()` at the start of the three `notify_by_address*` entry points in `src/tbb/address_waiter.cpp`, restoring the documented fence-on-both-sides protocol for every `d1::mutex` / `d1::rw_mutex` / `waitable_atomic` user. The cost is confined to the notify slow path, which is reached only when a contended waiter is or may be present. The patch applies cleanly to v2021.13.0, v2021.13.3, and current mainline.

With the fence in place, GCC 12 emits `dmb ish` at the top of each function on
aarch64.

## Reproduction

No minimal reproducer yet — in our workload (OpenVINO inference on a 64-core Graviton 3 under sustained concurrent load) the hang appears after hours to days; the window is a few instructions wide and needs a contended `d1::rw_mutex` whose unlock races a committing waiter. The live-process forensics above (futex args from `/proc/<tid>/syscall`, mutex/node/bucket state from `/proc/<pid>/mem`) can be used to positively identify the condition in any hung process:

1. a thread parked in `wait_on_address` whose sleep node is still linked in its `address_waiter_table` bucket,
2. the waited address containing a value that satisfies the waiter's predicate (e.g. rw_mutex `m_state == WRITER_PENDING`), and
3. the bucket epoch equal to the node epoch.

## Second capture and intervention confirmation

We reproduced the hang a second time on the same setup. The second specimen had the identical shape but a different victim lock: a **`d1::mutex`** (`waitable_atomic<bool>`, taken in the same `spawn → advertise_new_work → request_workers` path) whose flag byte was `0` (**unlocked**) while a writer-context waiter slept on it — node linked as the sole element of its bucket, `my_is_in_list == 1`, and bucket epoch equal to the node epoch (`0x737ce`). So both notify entry points involved (`notify_by_address` from `rw_mutex::unlock`, `notify_by_address_one` from `mutex::unlock`) have been observed losing a wakeup in the wild.

We then confirmed the diagnosis by intervention. After a few hours stuck, we used a single-thread ptrace injection to make one idle thread in the hung process execute exactly the call the buggy path skipped:

```
tbb::detail::r1::notify_by_address_all(&stuck_mutex);
```

The sleeping waiter woke within a second, the bucket epoch advanced (`0x737ce → 0x737d1`) as organic notify traffic resumed, the thread that had been spinning in the dispatch loop completed its parallel region, and the process fully recovered — it served an inference request normally 120 ms later. No other state was modified: delivering the one lost notification was sufficient to restore the process, which isolates the failure to the skipped notification itself.