### PR TITLE
Introduce new constructors for flow::resource_limiter

### DIFF
--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -21,6 +21,8 @@
 #error Do not #include this internal file directly; use public TBB headers instead.
 #endif
 
+#include "_range_common.h"
+
 #include <unordered_map>
 #include <forward_list>
 #include <functional>
@@ -152,6 +154,11 @@ public:
     resource_limiter(Handle&& handle, Handles&&... handles) {
         emplace_handles(std::forward<Handle>(handle), std::forward<Handles>(handles)...);
     }
+
+    template <typename InputIterator>
+    resource_limiter(InputIterator first, InputIterator last)
+        : m_resource_handles(first, last)
+    {}
 
     void request(consumer_type& consumer, request_id id) override {
         // TODO: consider using an aggregator instead of mutex

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -60,20 +60,20 @@ public:
     };
 }; // class request_id
 
-struct in_place_t {};
-
 template <typename ResourceHandle>
 class resource_handle_optional {
     union {
         ResourceHandle m_resource_handle;
     };
     bool m_has_value;
-
+    
     template <typename... Args>
     void construct(Args&&... args) {
         ::new(&m_resource_handle) ResourceHandle(std::forward<Args>(args)...);
     }
 public:
+    struct in_place_t {};
+
     resource_handle_optional()
         : m_has_value(false)
     {}
@@ -191,7 +191,7 @@ public:
         } else {
             ResourceHandle handle = std::move(m_resource_handles.front());
             m_resource_handles.pop_front();
-            return {in_place_t{}, std::move(handle)};
+            return {typename optional_type::in_place_t{}, std::move(handle)};
         }
     }
 

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -162,8 +162,7 @@ public:
     resource_limiter(InputIterator first, InputIterator last)
         : m_resource_handles(first, last)
     {
-        __TBB_ASSERT(std::distance(m_resource_handles.begin(), m_resource_handles.end()),
-                     "Attempt to create a resource_limiter with 0 resource handles");
+        __TBB_ASSERT(!m_resource_handles.empty(), "Attempt to create a resource_limiter with 0 resource handles");
     }
 
     template <typename ContainerBasedSequence,

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -150,17 +150,24 @@ public:
     using consumer_type = typename resource_provider_base<ResourceHandle>::consumer_type;
     using optional_type = typename resource_provider_base<ResourceHandle>::optional_type;
 
+    resource_limiter() = delete;
+
     template <typename Tuple, typename... Tuples>
     resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples) {
         emplace_handles(std::forward<Tuple>(tuple), std::forward<Tuples>(tuples)...);
     }
 
-    template <typename InputIterator>
+    template <typename InputIterator,
+              typename = typename std::iterator_traits<InputIterator>::iterator_category>
     resource_limiter(InputIterator first, InputIterator last)
         : m_resource_handles(first, last)
-    {}
+    {
+        __TBB_ASSERT(std::distance(first, last) != 0, "Attempt to create a resource_limiter with 0 resource handles");
+    }
 
-    template <typename ContainerBasedSequence>
+    template <typename ContainerBasedSequence,
+              typename = decltype(std::begin(std::declval<ContainerBasedSequence&>())),
+              typename = decltype(std::end(std::declval<ContainerBasedSequence&>()))>
     resource_limiter(ContainerBasedSequence&& sequence)
         : resource_limiter(std::begin(sequence), std::end(sequence))
     {}
@@ -222,8 +229,10 @@ private:
 
     template <typename Tuple, typename... Tuples>
     void emplace_handles(Tuple&& tuple, Tuples&&... tuples) {
+        using decayed_tuple = typename std::decay<Tuple>::type;
+
         emplace_single_handle(std::forward<Tuple>(tuple),
-                              tbb::detail::make_index_sequence<std::tuple_size<Tuple>::value>());
+                              tbb::detail::make_index_sequence<std::tuple_size<decayed_tuple>::value>());
         emplace_handles(std::forward<Tuples>(tuples)...);
     }
 

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -60,6 +60,8 @@ public:
     };
 }; // class request_id
 
+struct in_place_t {};
+
 template <typename ResourceHandle>
 class resource_handle_optional {
     union {
@@ -72,8 +74,6 @@ class resource_handle_optional {
         ::new(&m_resource_handle) ResourceHandle(std::forward<Args>(args)...);
     }
 public:
-    struct in_place_t {};
-
     resource_handle_optional()
         : m_has_value(false)
     {}
@@ -150,14 +150,23 @@ public:
     using consumer_type = typename resource_provider_base<ResourceHandle>::consumer_type;
     using optional_type = typename resource_provider_base<ResourceHandle>::optional_type;
 
-    template <typename Handle, typename... Handles>
-    resource_limiter(Handle&& handle, Handles&&... handles) {
-        emplace_handles(std::forward<Handle>(handle), std::forward<Handles>(handles)...);
+    template <typename Tuple, typename... Tuples>
+    resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples) {
+        emplace_handles(std::forward<Tuple>(tuple), std::forward<Tuples>(tuples)...);
     }
 
     template <typename InputIterator>
     resource_limiter(InputIterator first, InputIterator last)
         : m_resource_handles(first, last)
+    {}
+
+    template <typename ContainerBasedSequence>
+    resource_limiter(ContainerBasedSequence&& sequence)
+        : resource_limiter(std::begin(sequence), std::end(sequence))
+    {}
+
+    resource_limiter(std::initializer_list<ResourceHandle> init)
+        : resource_limiter(init.begin(), init.end())
     {}
 
     void request(consumer_type& consumer, request_id id) override {
@@ -182,7 +191,7 @@ public:
         } else {
             ResourceHandle handle = std::move(m_resource_handles.front());
             m_resource_handles.pop_front();
-            return {typename optional_type::in_place_t{}, std::move(handle)};
+            return {in_place_t{}, std::move(handle)};
         }
     }
 
@@ -206,10 +215,16 @@ public:
     using consumer_data = std::pair<request_id, resource_consumer_base<ResourceHandle>*>;
 
 private:
-    template <typename Handle, typename... Handles>
-    void emplace_handles(Handle&& handle, Handles&&... handles) {
-        m_resource_handles.emplace_front(std::forward<Handle>(handle));
-        emplace_handles(std::forward<Handles>(handles)...);
+    template <typename Tuple, std::size_t... Idx>
+    void emplace_single_handle(Tuple&& tuple, tbb::detail::index_sequence<Idx...>) {
+        m_resource_handles.emplace_front(std::get<Idx>(std::forward<Tuple>(tuple))...);
+    }
+
+    template <typename Tuple, typename... Tuples>
+    void emplace_handles(Tuple&& tuple, Tuples&&... tuples) {
+        emplace_single_handle(std::forward<Tuple>(tuple),
+                              tbb::detail::make_index_sequence<std::tuple_size<Tuple>::value>());
+        emplace_handles(std::forward<Tuples>(tuples)...);
     }
 
     void emplace_handles() {}

--- a/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
+++ b/include/oneapi/tbb/detail/_flow_graph_resource_limiting.h
@@ -162,7 +162,8 @@ public:
     resource_limiter(InputIterator first, InputIterator last)
         : m_resource_handles(first, last)
     {
-        __TBB_ASSERT(std::distance(first, last) != 0, "Attempt to create a resource_limiter with 0 resource handles");
+        __TBB_ASSERT(std::distance(m_resource_handles.begin(), m_resource_handles.end()),
+                     "Attempt to create a resource_limiter with 0 resource handles");
     }
 
     template <typename ContainerBasedSequence,

--- a/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
+++ b/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
@@ -164,7 +164,7 @@ The concern with this constructor is that the number of resources should be know
 The current implementation of ``resource_limiter`` uses ``std::forward_list`` container which already provides the necessary runtime semantics, so the
 only concern is the ``resource_limiter`` constructor itself.
 
-The idea is to extend the set of constructors to accept arbitrary containers (or ranges) to define the number of resources and its values in runtime.
+The idea is to extend the set of constructors to accept arbitrary containers (or ranges) to define the number of resources and their values at runtime.
 
 ```cpp
 template <typename ResourceHandle>

--- a/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
+++ b/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
@@ -8,10 +8,11 @@ Note: This document is a sub-RFC for the [Resource-limited Nodes RFC](./README.m
   * 1.1 [Terminology](#terminology)
   * 1.2 [Proposed Design](#proposed-design)
   * 1.3 [API Details](#api-details)
-  * 1.4 [API Specification](#api-specification)
-    * 1.4.1 [`oneapi::tbb::flow::resource_limiter` Class](#oneapitbbflowresource_limiter-class)
-    * 1.4.2 [`ResourceLimitedBody` Named Requirements](#resourcelimitedbody-named-requirements)
-    * 1.4.3 [`oneapi::tbb::flow::resource_limited_node` Class](#oneapitbbflowresource_limited_node-class)
+  * 1.4 [Extending the ``resource_limiter`` Constructors](#extending-the-resource_limiter-constructors)
+  * 1.5 [API Specification](#api-specification)
+    * 1.5.1 [`oneapi::tbb::flow::resource_limiter` Class](#oneapitbbflowresource_limiter-class)
+    * 1.5.2 [`ResourceLimitedBody` Named Requirements](#resourcelimitedbody-named-requirements)
+    * 1.5.3 [`oneapi::tbb::flow::resource_limited_node` Class](#oneapitbbflowresource_limited_node-class)
 * 2 [API to Support Polymorphic Providers](#api-to-support-polymorphic-providers)
 * 3 [Exit Criteria and Open Questions](#exit-criteria-and-open-questions)
 * 4 [Usage Examples](#usage-examples)
@@ -139,6 +140,200 @@ When the resource is used by one of the nodes in the Flow Graph, the `resource_l
 If access to one or several resources cannot be granted immediately, the node and the provider utilize the unspecified *Protocol*, which defines
 how and when access will be granted to each node that requests it. The concurrency held by the currently processed input message is not 
 released until all necessary resource accesses are granted and the body is executed.
+
+### Extending the ``resource_limiter`` Constructors
+
+The initial version of the resource limiting feature in the Flow Graph supported a single constructor for ``tbb::flow::resource_limiter`` class,
+accepting a variadic number of resources:
+
+```cpp
+template <typename ResourceHandle>
+class resource_limiter {
+public:
+    template <typename Handle, typename... Handles>
+    resource_limiter(Handle&& handle, Handles&&... handles) // Constructor (1)
+    {}
+};
+
+resource_limiter<int> limiter(1, 2, 3, 4, 5);
+```
+
+In the code above, ``limiter`` manages 5 resources of type ``int``. Instances of resources are constructed in-place while constructing the limiter.
+The concern with this constructor is that the number of resources should be known at compile-time, while some workflows only knows it in runtime.
+
+Current underneath implementation of ``resource_limiter`` uses ``std::forward_list`` container which already provides a necessary runtime semantics, so the
+only concern is the ``resource_limiter`` constructor itself.
+
+The idea is to extend the set of constructors to accept arbitrary containers (or ranges) to define the number of resources and its values in runtime.
+
+```cpp
+template <typename ResourceHandle>
+class resource_limiter {
+public:
+    template <typename Handle, typename... Handles>
+    resource_limiter(Handle&& handle, Handles&&... handles) // Constructor (1) - existing
+    {}
+
+    template <typename InputIterator>
+    resource_limiter(InputIterator first, InputIterator last) // Constructor (2) - extension
+    {}
+
+    template <typename ContainerBasedSequence>
+    resource_limiter(ContainerBasedSequence&& sequence) // Constructor (3) - extension
+    {}
+};
+
+resource_limiter<int> limiter1{1, 2, 3}; // Resources are directly passed, constructed in-place
+
+std::vector<int> vector = {1, 2, 3};
+resource_limiter<int> limiter2{vector.begin(), vector.end()}; // [first, last) constructors, resources are copied from vector
+
+resource_limiter<int> limiter3{vector}; // Same as above
+```
+
+Constructor (2) creates a ``resource_limiter`` containing all the resources in a range ``[first, last)``. Constructor (3) is just a syntactic sugar over
+the constructor (2) - it is equivalent to ``resource_limiter(std::begin(sequence), std::end(sequence))``.
+
+However, adding constructors (2) and (3) introduces an overload ambiguity when 1 or 2 resources are passed directly to the limiter constructor:
+
+```cpp
+resource_limiter<int> limiter1(1);
+resource_limiter<int> limiter2(1, 2);
+```
+
+For ``limiter1`` and ``limiter2``, the constructors (2) and (3) respectively are better matches than constructor (1) due to absence of the variadic.
+This can cause compilation failures, because an ``int`` may be treated as a sequence in constructor (3), or incorrect runtime behavior if two
+integers are interpreted as arguments to the ``forward_list`` constructor in constructor (2).
+
+This issue should be solved by disambiguating constructor (1), which performs in-place construction, from constructors (2) and (3), which perform
+range-based construction.
+The following techniques were considered:
+
+1. Implicit disambiguation by constraining the constructor overloads: constructor (1) may only participate in overload resolution when
+   ``ResourceHandle`` is constructible from all ``Handle`` arguments, constructor (2) only when the argument is an input iterator, and
+   constructor (3) only when the argument is a ``ContainerBasedSequence``. However, this approach will not work for corner cases where
+   ``ResourceHandle`` itself is an iterator or a sequence.
+2. Replace the constructors with factory functions with explicit names. For example, ``tbb::flow::get_resource_limiter_from_range(first, last)``.
+   Currently, this approach cannot be used because ``resource_limiter`` is not guaranteed to be movable, so it cannot be returned from
+   a factory function in C++11.
+3. Use ``std::initializer_list`` for constructor (1). Requires the ``ResourceHandle`` to be copyable.
+4. Explicit disambiguation by adding tag arguments to the constructors. Different tagged constructors help ensure that the correct constructor
+   is chosen. This option will be described below.
+
+There are three possible approaches for introducing a tagged constructor.
+
+The first approach is to use a tag for constructor (1). Since the resources are constructed in place, ``std::in_place_t`` is a natural candidate.
+The only issue is that ``std::in_place_t`` is available only starting in C++17, so supporting C++11/14 would require introducing a public
+``tbb::in_place_t`` type:
+
+```cpp
+// Constructors
+template <typename Handle, typename... Handles>
+resource_limiter(tbb::in_place_t, Handle&& handle, Handles&&... handles);
+
+template <typename InputIterator>
+resource_limiter(InputIterator first, InputIterator last);
+
+template <typename ContainerBasedSequence>
+resource_limiter(ContainerBasedSequence&& sequence);
+
+// Usage
+resource_limiter<int> limiter1(tbb::in_place_t{}, 1, 2, 3);
+
+std::vector<int> resources = {1, 2, 3};
+resource_limiter<int> limiter2(resources.begin(), resources.end());
+
+resource_limiter<int> limiter3(resources);
+```
+
+This would also break source compatibility with existing uses of constructor (1), but that may be acceptable for a preview feature.
+
+The second option is the opposite: use the tag only for the new constructors. A semantically close option is ``std::from_range_t``. Because this tag
+is a C++23 feature, supporting older C++ versions would require a public TBB alternative as well.
+
+```cpp
+// Constructors
+template <typename Handle, typename... Handles>
+resource_limiter(Handle&& handle, Handles&&... handles);
+
+template <typename InputIterator>
+resource_limiter(tbb::from_range_t, InputIterator first, InputIterator last);
+
+template <typename ContainerBasedSequence>
+resource_limiter(tbb::from_range_t, ContainerBasedSequence&& sequence);
+
+// Usage
+resource_limiter<int> limiter1(1, 2, 3);
+
+std::vector<int> resources = {1, 2, 3};
+resource_limiter<int> limiter2(tbb::from_range_t{}, resources.begin(), resources.end());
+
+resource_limiter<int> limiter3(tbb::from_range_t{}, resources);
+```
+
+This approach preserves source compatibility with existing code.
+
+The last option is to modify constructor (1) to use ``std::piecewise_construct_t``. This would change the constructor's semantics, but it
+would also make it a more powerful version of the existing constructor (1).
+
+```cpp
+// Constructors
+template <typename Tuple, typename... Tuples>
+resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples);
+
+template <typename InputIterator>
+resource_limiter(InputIterator first, InputIterator last);
+
+template <typename ContainerBasedSequence>
+resource_limiter(ContainerBasedSequence&& sequence);
+
+// Usage
+resource_limiter<int> limiter1(std::piecewise_construct, std::forward_as_tuple(1),
+                                                         std::forward_as_tuple(2),
+                                                         std::forward_as_tuple(3));
+
+std::vector<int> resources = {1, 2, 3};
+resource_limiter<int> limiter2(resources.begin(), resources.end());
+
+resource_limiter<int> limiter3(resources);
+```
+
+Such a constructor would replace usages of constructor (1) with a less simple form, because each argument would need to
+be forwarded as a tuple. However, it also extends the API to support cases where a resource should be constructed in place from a set
+of arguments rather than a single one, which was not possible with the existing constructor and would otherwise require explicit
+move construction:
+
+```cpp
+struct resource {
+    resource(const char* name, std::unique_ptr<int> memory);
+};
+
+resource_limiter<resource> limiter(std::piecewise_construct, std::forward_as_tuple("my resource", std::make_unique<int>(123)));
+```
+
+This approach does not require introducing extra public tags in the ``tbb`` namespace, and it does not preserve source compatibility.
+
+The proposal is to use the combination of two approaches - the ``std::initializer_list`` and a tagged constructor with piecewise argument.
+``std::initializer_list`` would cover most of the use cases of the existing constructor (1) without introducing extra complexity,
+while the piecewise constructor will cover the rest, as well as more complex use-cases not covered by the existing constructors set.
+
+```cpp
+template <typename ResourceHandle>
+class resource_limiter {
+    template <typename InputIterator>
+    resource_limiter(InputIterator first, InputIterator last);
+
+    template <typename ContainerBasedSequence>
+    resource_limiter(ContainerBasedSequence&& sequence)
+        : resource_limiter(std::begin(sequence), std::end(sequence)) {}
+
+    resource_limiter(std::initializer_list<ResourceHandle> init)
+        : resource_limiter(init.begin(), init.end()) {}
+
+    template <typename Tuple, typename... Tuples>
+    resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples);
+};
+```
 
 ### API Specification
 

--- a/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
+++ b/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
@@ -194,6 +194,11 @@ resource_limiter<int> limiter3{vector}; // Same as above
 Constructor (2) creates a ``resource_limiter`` containing all the resources in a range ``[first, last)``. Constructor (3) is just a syntactic sugar over
 the constructor (2) - it is equivalent to ``resource_limiter(std::begin(sequence), std::end(sequence))``.
 
+The only limitation that cannot be enforced at compile time is that the number of resources in a range ``[first, last)`` must not be ``0``.
+Constructor (1) enforces this by requiring at least one argument. For constructors (2) and (3), the number of resources is runtime information, so it can
+only be checked at runtime, for example via an assert (in debug mode), an exception, or a similar mechanism. The current proposal is to document the empty
+range as undefined behavior and add an assert in debug mode.
+
 However, adding constructors (2) and (3) introduces an overload ambiguity when 1 or 2 resources are passed directly to the limiter constructor:
 
 ```cpp

--- a/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
+++ b/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
@@ -161,7 +161,7 @@ resource_limiter<int> limiter(1, 2, 3, 4, 5);
 In the code above, ``limiter`` manages 5 resources of type ``int``. Instances of resources are constructed in-place while constructing the limiter.
 The concern with this constructor is that the number of resources should be known at compile-time, while some workflows only knows it in runtime.
 
-Current underneath implementation of ``resource_limiter`` uses ``std::forward_list`` container which already provides a necessary runtime semantics, so the
+The current implementation of ``resource_limiter`` uses ``std::forward_list`` container which already provides the necessary runtime semantics, so the
 only concern is the ``resource_limiter`` constructor itself.
 
 The idea is to extend the set of constructors to accept arbitrary containers (or ranges) to define the number of resources and its values in runtime.

--- a/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
+++ b/rfcs/proposed/flow_graph_serializers/resource_consumer_node_api.md
@@ -159,7 +159,7 @@ resource_limiter<int> limiter(1, 2, 3, 4, 5);
 ```
 
 In the code above, ``limiter`` manages 5 resources of type ``int``. Instances of resources are constructed in-place while constructing the limiter.
-The concern with this constructor is that the number of resources should be known at compile-time, while some workflows only knows it in runtime.
+The concern with this constructor is that the number of resources should be known at compile-time, while some workflows only know it in runtime.
 
 The current implementation of ``resource_limiter`` uses ``std::forward_list`` container which already provides the necessary runtime semantics, so the
 only concern is the ``resource_limiter`` constructor itself.

--- a/test/tbb/test_flow_graph_whitebox.cpp
+++ b/test/tbb/test_flow_graph_whitebox.cpp
@@ -645,7 +645,7 @@ void TestResourceLimitedNode() {
     using policy_type = tbb::flow::queueing;
     using multinode_type = tbb::flow::resource_limited_node<int, std::tuple<int, int>>;
 
-    tbb::flow::resource_limiter<int> limiter(1);
+    tbb::flow::resource_limiter<int> limiter{1};
     TestMultiNode<multinode_type, policy_type>("Testing resource_limited_node", std::tie(limiter));
 }
 #endif

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -25,6 +25,8 @@
 
 #include "tbb/flow_graph.h"
 
+#include <array>
+
 //! \file test_resource_limited_node.cpp
 //! \brief Test for [preview] functionality
 
@@ -379,6 +381,47 @@ void test_cancellation_with_active_requests(bool same_graph, bool exception) {
     }
 }
 
+template <typename ArrayType, typename... ConstructorArgs>
+void test_resource_limiter_constructor(const ArrayType& resource_values, ConstructorArgs&&... constructor_args) {
+    using namespace oneapi::tbb::flow;
+    using resource_type = typename ArrayType::value_type;
+
+    resource_limiter<int> limiter(std::forward<ConstructorArgs>(constructor_args)...);
+
+    graph g;
+
+    using node_type = resource_limited_node<int, std::tuple<>>;
+    using ports_type = typename node_type::output_ports_type;
+    std::atomic<std::size_t> counter(0);
+
+    auto node_body = [&](int, ports_type&, int resource) {
+        auto is_equal = [=](const resource_type& value) { return value == resource; };
+        CHECK_MESSAGE(std::any_of(resource_values.begin(), resource_values.end(), is_equal),
+                      "Unexpected resource");
+                      
+        ++counter;
+        for (std::size_t i = 0; i < 1000; ++i) {
+            CHECK_MESSAGE(counter <= resource_values.size(), "Detected more resources than expected");
+        }
+        --counter;
+    };
+
+    node_type node(g, unlimited, std::tie(limiter), node_body);
+
+    for (std::size_t i = 0; i < 1000; ++i) {
+        node.try_put(0);
+    }
+    g.wait_for_all();
+    CHECK(counter == 0);
+}
+
+template <std::size_t... Idx, std::size_t N>
+void test_resource_limiter_handles_constructor(std::array<int, N>& resources,
+                                               std::index_sequence<Idx...>) {
+    CHECK(sizeof...(Idx) == N);
+    test_resource_limiter_constructor(resources, resources[Idx]...);
+}
+
 //! \brief \ref interface
 TEST_CASE("Feature test macro") {
     CHECK_MESSAGE(TBB_HAS_FLOW_GRAPH_RESOURCE_LIMITING == 202603, "Incorrect feature test macro");
@@ -568,3 +611,12 @@ TEST_CASE("concurrency limit with multiple resources") {
                  "Expected to observe concurrent execution but max_observed=" << max_observed.load());
 }
 
+//! \brief \ref interface \ref requirement
+TEST_CASE("resource_limiter constructors") {
+    std::array<int, 2> resources = {1, 2};
+    // test resource_limiter(Handle&& handle, Handles&&... handles)
+    test_resource_limiter_handles_constructor(resources, std::make_index_sequence<resources.size()>());
+
+    // test resource_limiter(InputIterator first, InputIterator last)
+    test_resource_limiter_constructor(resources, resources.begin(), resources.end());
+}

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -437,8 +437,7 @@ template <typename T, std::size_t N>
 void test_resource_limiter_constructors(std::array<T, N>& resources) {
     auto index_sequence = tbb::detail::make_index_sequence<N>();
 
-    // Test resource_limiter(Handle&& handle, Handles&&... handles)
-    test_resource_limiter_handles_constructor(resources, index_sequence);
+    // Test resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples)
 
     // Test resource_limiter(std::initializer_list<ResourceHandle> init)
     test_resource_limiter_initializer_list_constructor(resources, index_sequence);

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -178,7 +178,8 @@ void test_strict_resource_handle() {
     using namespace tbb::flow;
 
     int handle_value = 42;
-    resource_limiter<strict_resource_handle> limiter{strict_resource_handle_provider::construct(handle_value)};
+    resource_limiter<strict_resource_handle> limiter(std::piecewise_construct,
+                                                     std::forward_as_tuple(strict_resource_handle_provider::construct(handle_value)));
 
     using node_type = resource_limited_node<int, std::tuple<>>;
     using ports_type = typename node_type::output_ports_type;
@@ -221,8 +222,8 @@ void test_root_genie() {
     using node_type = resource_limited_node<int, std::tuple<int>>;
     using ports_type = typename node_type::output_ports_type;
 
-    resource_limiter<counting_resource*> root_limiter(&root_resource);
-    resource_limiter<counting_resource*> genie_limiter(&genie_resource);
+    resource_limiter<counting_resource*> root_limiter{&root_resource};
+    resource_limiter<counting_resource*> genie_limiter{&genie_resource};
 
     graph g;
 
@@ -305,7 +306,7 @@ void test_cancellation_with_active_requests(bool same_graph, bool exception) {
 
     int resource_value = 1;
     int input_value = 2;
-    resource_limiter<int> limiter(resource_value);
+    resource_limiter<int> limiter{resource_value};
 
     using node_type = resource_limited_node<int, std::tuple<>>;
     using ports_type = typename node_type::output_ports_type;
@@ -386,7 +387,7 @@ void test_resource_limiter_constructor(const ArrayType& resource_values, Constru
     using namespace oneapi::tbb::flow;
     using resource_type = typename ArrayType::value_type;
 
-    resource_limiter<int> limiter(std::forward<ConstructorArgs>(constructor_args)...);
+    resource_limiter<resource_type> limiter(std::forward<ConstructorArgs>(constructor_args)...);
 
     graph g;
 
@@ -394,7 +395,7 @@ void test_resource_limiter_constructor(const ArrayType& resource_values, Constru
     using ports_type = typename node_type::output_ports_type;
     std::atomic<std::size_t> counter(0);
 
-    auto node_body = [&](int, ports_type&, int resource) {
+    auto node_body = [&](int, ports_type&, resource_type resource) {
         auto is_equal = [=](const resource_type& value) { return value == resource; };
         CHECK_MESSAGE(std::any_of(resource_values.begin(), resource_values.end(), is_equal),
                       "Unexpected resource");
@@ -408,18 +409,45 @@ void test_resource_limiter_constructor(const ArrayType& resource_values, Constru
 
     node_type node(g, unlimited, std::tie(limiter), node_body);
 
-    for (std::size_t i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 1000; ++i) {
         node.try_put(0);
     }
     g.wait_for_all();
     CHECK(counter == 0);
 }
 
-template <std::size_t... Idx, std::size_t N>
-void test_resource_limiter_handles_constructor(std::array<int, N>& resources,
-                                               std::index_sequence<Idx...>) {
-    CHECK(sizeof...(Idx) == N);
-    test_resource_limiter_constructor(resources, resources[Idx]...);
+template <std::size_t... Idx, typename ArrayType>
+void test_resource_limiter_handles_constructor(ArrayType& resources,
+                                               tbb::detail::index_sequence<Idx...>) {
+    CHECK(sizeof...(Idx) == resources.size());
+    test_resource_limiter_constructor(/*resource_values = */resources,
+                                      /*args = */std::piecewise_construct, std::forward_as_tuple(resources[Idx])...);
+}
+
+template <std::size_t... Idx, typename ArrayType>
+void test_resource_limiter_initializer_list_constructor(ArrayType& resources,
+                                                        tbb::detail::index_sequence<Idx...>) {
+    CHECK(sizeof...(Idx) == resources.size());
+    using value_type = typename ArrayType::value_type;
+    std::initializer_list<value_type> init = {resources[Idx]...};
+    test_resource_limiter_constructor(/*resource_values = */resources, /*args = */init);
+} 
+
+template <typename T, std::size_t N>
+void test_resource_limiter_constructors(std::array<T, N>& resources) {
+    auto index_sequence = tbb::detail::make_index_sequence<N>();
+
+    // Test resource_limiter(Handle&& handle, Handles&&... handles)
+    test_resource_limiter_handles_constructor(resources, index_sequence);
+
+    // Test resource_limiter(std::initializer_list<ResourceHandle> init)
+    test_resource_limiter_initializer_list_constructor(resources, index_sequence);
+
+    // Test resource_limiter(InputIterator first, InputIterator last)
+    test_resource_limiter_constructor(/*resource_values = */resources, /*args = */resources.begin(), resources.end());
+
+    // Test resource_limiter(ContainerBasedSequence&& sequence)
+    test_resource_limiter_constructor(/*resource_values = */resources, /*args = */resources);
 }
 
 //! \brief \ref interface
@@ -448,7 +476,7 @@ using limiter_unique_ptr = std::unique_ptr<oneapi::tbb::flow::resource_limiter<H
 
 template <std::size_t... Idx>
 limiter_unique_ptr<std::size_t> get_limiter_impl(tbb::detail::index_sequence<Idx...>) {
-    return limiter_unique_ptr<std::size_t>(new oneapi::tbb::flow::resource_limiter<std::size_t>(Idx...));
+    return limiter_unique_ptr<std::size_t>(new oneapi::tbb::flow::resource_limiter<std::size_t>({Idx...}));
 }
 
 template <std::size_t NumResources>
@@ -613,10 +641,12 @@ TEST_CASE("concurrency limit with multiple resources") {
 
 //! \brief \ref interface \ref requirement
 TEST_CASE("resource_limiter constructors") {
-    std::array<int, 2> resources = {1, 2};
-    // test resource_limiter(Handle&& handle, Handles&&... handles)
-    test_resource_limiter_handles_constructor(resources, std::make_index_sequence<resources.size()>());
+    std::array<int, 1> one_resource = {1};
+    test_resource_limiter_constructors(one_resource);
 
-    // test resource_limiter(InputIterator first, InputIterator last)
-    test_resource_limiter_constructor(resources, resources.begin(), resources.end());
+    std::array<int, 2> two_resources = {1, 2};
+    test_resource_limiter_constructors(two_resources);
+
+    std::array<int, 3> three_resources = {1, 2, 3};
+    test_resource_limiter_constructors(three_resources);
 }

--- a/test/tbb/test_resource_limited_node.cpp
+++ b/test/tbb/test_resource_limited_node.cpp
@@ -438,6 +438,7 @@ void test_resource_limiter_constructors(std::array<T, N>& resources) {
     auto index_sequence = tbb::detail::make_index_sequence<N>();
 
     // Test resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples)
+    test_resource_limiter_handles_constructor(resources, index_sequence);
 
     // Test resource_limiter(std::initializer_list<ResourceHandle> init)
     test_resource_limiter_initializer_list_constructor(resources, index_sequence);


### PR DESCRIPTION
### Description 
Change a set of constructors for `tbb::flow::resource_limiter` class:

```cpp
template <typename ResourceHandle>
class resource_limiter {
public:
    template <typename InputIterator>
    resource_limiter(InputIterator first, InputIterator last);
    
    template <typename ContainerBasedSequence>
    resource_limiter(ContainerBasedSequence&& sequence);
    
    resource_limiter(std::initializer_list<ResourceHandle> init);
    
    template <typename Tuple, typename... Tuples>
    resource_limiter(std::piecewise_construct_t, Tuple&& tuple, Tuples&&... tuples);
};
```

Updated the RFC with the motivation


Fixes #2131 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
