### PR TITLE
Restore build of tbb library with TBB_USE_EXCEPTIONS=0

### DIFF
--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -315,7 +315,9 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
 
     // Infinite exception loop
     for (;;) {
+#if TBB_USE_EXCEPTIONS
         try {
+#endif
             // Main execution loop
             do {
                 // We assume that bypass tasks are from the same task group.
@@ -382,6 +384,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                 );
             } while (t != nullptr); // main dispatch loop
             break; // Exit exception loop;
+#if TBB_USE_EXCEPTIONS
         } catch (...) {
             if (global_control::active_value(global_control::terminate_on_exception) == 1) {
                 do_throw_noexcept([] { throw; });
@@ -397,6 +400,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
                 }
             }
         }
+#endif /* TBB_USE_EXCEPTIONS */
     } // Infinite exception loop
     __TBB_ASSERT(t == nullptr, nullptr);
 


### PR DESCRIPTION
### Description 
According to TBB_USE_EXCEPTIONS feature macro, it's propose is to eliminate `try`, `catch`, and `throw` from the compiled code. So, probably, with `TBB_USE_EXCEPTIONS=0` build with `-fno-exceptions` should be possible. If this interpretation is correct, solution from #864 is only partially resolves the problem, as `try` still present in the compiled code. As an additional argument, TBB build with `TBB_USE_EXCEPTIONS=0` but without `-fno-exceptions` behaves similarly to `global_control::terminate_on_exception` enabled, so there may be little reason for this mode to exist.

Alex Katranov in #414 wrote that "It was possible to build TBB runtime with TBB_USE_EXCEPTIONS=0; however, it was neither supported nor tested."

### Type of change

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
