### PR TITLE
Explicitely prohibit resuming after calling of assertion_handler

### DIFF
--- a/doc/main/reference/assertion_handler.rst
+++ b/doc/main/reference/assertion_handler.rst
@@ -63,7 +63,7 @@ Functions
 Sets the provided assertion handler and returns the previous handler. If ``new_handler`` is ``nullptr``, resets to the
 default handler.
 
-.. note:: ``new_handler`` must not return. If it does, the behavior is undefined.
+.. note:: ``new_handler`` must terminate the program and must not return. Otherwise the behavior is undefined.
 
 .. cpp:function:: assertion_handler_type get_assertion_handler() noexcept
 

--- a/doc/main/reference/assertion_handler.rst
+++ b/doc/main/reference/assertion_handler.rst
@@ -63,7 +63,7 @@ Functions
 Sets the provided assertion handler and returns the previous handler. If ``new_handler`` is ``nullptr``, resets to the
 default handler.
 
-.. note:: ``new_handler`` must terminate the program and must not return. Otherwise the behavior is undefined.
+.. note:: ``new_handler`` must terminate the program without returning. Otherwise the behavior is undefined.
 
 .. cpp:function:: assertion_handler_type get_assertion_handler() noexcept
 


### PR DESCRIPTION
### Description 
Motivation for the change is that we can't guarantee anything after assertion triggering, so let's say this explicitly. It's also matches the expectation for global terminate handler function.

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [X] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [X] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
