### PR TITLE
Fix no member named 'hardware_destructive_interference_size'

### DIFF
--- a/include/oneapi/tbb/cache_aligned_allocator.h
+++ b/include/oneapi/tbb/cache_aligned_allocator.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Copyright (c) 2005-2022 Intel Corporation
     Copyright (c) 2026 UXL Foundation Contributors
 
@@ -22,6 +22,7 @@
 #include "detail/_namespace_injection.h"
 #include <cstdlib>
 #include <utility>
+#include <new>
 
 #if __TBB_CPP17_MEMORY_RESOURCE_PRESENT
 #include <memory_resource>


### PR DESCRIPTION
### Description 
The definition of `std::hardware_destructive_interference_size` is [found](https://en.cppreference.com/cpp/thread/hardware_destructive_interference_size) in the \<**new**\> header.

In some implementations of the standard library, it is included in the \<**vector**\> header.
For example, in the case of the MSVC STL, the \<**new**\> header is included as follows:
"**detail/_utils.h**" -\> \<**vector**\> -\> \<**xmemory**\> -\> \<**new**\>

However, this does not happen in libcxx, which is why the following error occurs:
<img width="1100" height="290" alt="image" src="https://github.com/user-attachments/assets/4ddea7bc-702b-450e-98e5-3fbab72bee8d" />

The solution is simple - explicitly add `#include <new>`
### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
This might also resolve issue #2024, but I'm not sure