### PR TITLE
fix for clang-ubsan complaining about type casts with overflow

### DIFF
--- a/include/oneapi/tbb/blocked_range.h
+++ b/include/oneapi/tbb/blocked_range.h
@@ -118,7 +118,7 @@ private:
     static Value do_split( blocked_range& r, split )
     {
         __TBB_ASSERT( r.is_divisible(), "cannot split blocked_range that is not divisible" );
-        Value middle = r.my_begin + (r.my_end - r.my_begin) / 2u;
+        Value middle = r.my_begin + (r.my_end - r.my_begin) / 2;
         r.my_end = middle;
         return middle;
     }

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -562,7 +562,7 @@ private:
     void internal_push( Args&&... args ) {
         unsigned old_abort_counter = my_abort_counter.load(std::memory_order_relaxed);
         ticket_type ticket = my_queue_representation->tail_counter++;
-        std::ptrdiff_t target = (std::ptrdiff_t)(ticket - my_capacity);
+        std::ptrdiff_t target = static_cast<std::ptrdiff_t>(ticket - my_capacity);
 
         if (static_cast<std::ptrdiff_t>(my_queue_representation->head_counter.load(std::memory_order_relaxed)) <= target) { // queue is full
             auto pred = [&] {

--- a/include/oneapi/tbb/concurrent_queue.h
+++ b/include/oneapi/tbb/concurrent_queue.h
@@ -562,7 +562,7 @@ private:
     void internal_push( Args&&... args ) {
         unsigned old_abort_counter = my_abort_counter.load(std::memory_order_relaxed);
         ticket_type ticket = my_queue_representation->tail_counter++;
-        std::ptrdiff_t target = ticket - my_capacity;
+        std::ptrdiff_t target = (std::ptrdiff_t)(ticket - my_capacity);
 
         if (static_cast<std::ptrdiff_t>(my_queue_representation->head_counter.load(std::memory_order_relaxed)) <= target) { // queue is full
             auto pred = [&] {


### PR DESCRIPTION
### Description 
_Add a comprehensive description of proposed changes_

Add explicit cast to mute clang's ubsan complaing about implicit type cast when it overflows

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
