### PR TITLE
Save settings from r1::arena to task_arena during attach

### DIFF
--- a/doc/main/specification/source/task_scheduler/task_arena/task_arena_cls.rst
+++ b/doc/main/specification/source/task_scheduler/task_arena/task_arena_cls.rst
@@ -220,7 +220,8 @@ Member functions
 
 .. cpp:function:: explicit task_arena(oneapi::tbb::attach)
 
-    Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread.
+    Creates an instance of ``task_arena`` that is connected to the internal task arena representation currently used by the calling thread
+    and copies its settings.
     If no such arena exists yet, creates a ``task_arena`` with default parameters.
 
     .. note::
@@ -316,13 +317,13 @@ Member functions
 
     The behavior of this function is equivalent to ``this->enqueue( tg.defer(std::forward<F>(f)) )``.
 
-.. cpp:function:: void enqueue(task_handle&& h)   
-     
-    Enqueues a task owned by ``h`` into the ``task_arena`` for processing. 
- 
-    The behavior of this function is equivalent to the generic version (``template<typename F> void task_arena::enqueue(F&& f)``), except parameter type. 
+.. cpp:function:: void enqueue(task_handle&& h)
 
-    .. note:: 
+    Enqueues a task owned by ``h`` into the ``task_arena`` for processing.
+
+    The behavior of this function is equivalent to the generic version (``template<typename F> void task_arena::enqueue(F&& f)``), except parameter type.
+
+    .. note::
        ``h`` should not be empty to avoid an undefined behavior.
 
 .. cpp:function:: task_group_status task_arena::wait_for(task_group& tg)
@@ -340,15 +341,15 @@ Non-member Functions
     Returns a ``std::vector`` of non-initialized ``task_arena`` objects, each bound to a separate NUMA node.
     The number of created ``task_arena`` instances is equal to the number of NUMA nodes on the system,
     as determined by ``tbb::info::numa_nodes()``.
-    
+
     If an error occurs during system information discovery,
-    returns a ``std::vector`` containing a single ``task_arena`` object created as 
+    returns a ``std::vector`` containing a single ``task_arena`` object created as
     ``task_arena(constraints_.set_numa_id(task_arena::automatic), reserved_slots)``.
 
     The ``constraints_`` argument can be specified to apply additional limitations to threads in
     the ``task_arena`` objects. For each created arena, the ``numa_id`` value in ``constraints_``
     is automatically set to the corresponding NUMA node ID from ``tbb::info::numa_nodes()``.
-    
+
     The ``reserved_slots`` argument allows reserving a specified number of slots in
     each ``task_arena`` object for application threads. By default, no slots are reserved.
 

--- a/include/oneapi/tbb/task_arena.h
+++ b/include/oneapi/tbb/task_arena.h
@@ -607,6 +607,25 @@ public:
         return my_max_concurrency;
     }
 
+    //! Returns my_priority
+    priority debug_priority() const {
+        return my_priority;
+    }
+
+    //! Returns leave policy
+    leave_policy debug_leave_policy() const {
+        return get_leave_policy();
+    }
+
+    //! Returns constraints
+    constraints debug_constraints() const {
+        return constraints{}
+            .set_numa_id(my_numa_id)
+            .set_max_concurrency(my_max_concurrency)
+            .set_core_type(my_core_type)
+            .set_max_threads_per_core(my_max_threads_per_core);
+    }
+
     //! Wait for all work in the arena to be completed
     //! Even submitted by other application threads
     //! Joins arena if/when possible (in the same way as execute())

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -244,8 +244,8 @@ void arena::process(thread_data& tls) {
     __TBB_ASSERT(tls.my_arena == this, "my_arena is used as a hint when searching the arena to join");
 }
 
-arena::arena(threading_control* control, unsigned num_slots, unsigned num_reserved_slots, unsigned priority_level
-             , tbb::task_arena::leave_policy lp)
+arena::arena(threading_control* control, unsigned num_slots, unsigned num_reserved_slots, unsigned priority_level,
+            d1::constraints constraints, tbb::task_arena::leave_policy lp)
 {
     __TBB_ASSERT( !my_guard, "improperly allocated arena?" );
     __TBB_ASSERT( sizeof(my_slots[0]) % cache_line_size()==0, "arena::slot size not multiple of cache line size" );
@@ -282,11 +282,16 @@ arena::arena(threading_control* control, unsigned num_slots, unsigned num_reserv
 #endif
     my_mandatory_requests = 0;
 
+    my_numa_id = constraints.numa_id;
+    my_core_type = constraints.core_type;
+    my_max_threads_per_core = constraints.max_threads_per_core;
+    my_leave_policy = lp;
+
     my_thread_leave.set_initial_state(lp);
 }
 
 arena& arena::allocate_arena(threading_control* control, unsigned num_slots, unsigned num_reserved_slots,
-                             unsigned priority_level, tbb::task_arena::leave_policy lp)
+                             unsigned priority_level, d1::constraints constraints, tbb::task_arena::leave_policy lp)
 {
     __TBB_ASSERT( sizeof(base_type) + sizeof(arena_slot) == sizeof(arena), "All arena data fields must go to arena_base" );
     __TBB_ASSERT( sizeof(base_type) % cache_line_size() == 0, "arena slots area misaligned: wrong padding" );
@@ -297,7 +302,7 @@ arena& arena::allocate_arena(threading_control* control, unsigned num_slots, uns
     std::memset( storage, 0, n );
 
     return *new( storage + num_arena_slots(num_slots, num_reserved_slots) * sizeof(mail_outbox) )
-        arena(control, num_slots, num_reserved_slots, priority_level, lp);
+        arena(control, num_slots, num_reserved_slots, priority_level, constraints, lp);
 }
 
 void arena::free_arena () {
@@ -461,7 +466,7 @@ arena &arena::create(threading_control *control, unsigned num_slots,
 {
     __TBB_ASSERT(num_slots > 0, NULL);
     // Add public market reference for an external thread/task_arena (that adds an internal reference in exchange).
-    arena& a = arena::allocate_arena(control, num_slots, num_reserved_slots, arena_priority_level, lp);
+    arena& a = arena::allocate_arena(control, num_slots, num_reserved_slots, arena_priority_level, constraints, lp);
     __TBB_ASSERT(a.my_num_reserved_slots <= a.my_num_slots, NULL);
     a.my_numa_binding_observer = observer;
     a.my_tc_client = control->create_client(a);
@@ -631,6 +636,10 @@ bool task_arena_impl::attach(d1::task_arena_base& ta) {
         ta.my_priority = arena_priority(a->my_priority_level);
         ta.my_max_concurrency = ta.my_num_reserved_slots + a->my_max_num_workers;
         __TBB_ASSERT(arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots) == a->my_num_slots, nullptr);
+        ta.my_numa_id = a->my_numa_id;
+        ta.my_core_type = a->my_core_type;
+        ta.my_max_threads_per_core = a->my_max_threads_per_core;
+        ta.set_leave_policy(a->my_leave_policy);
         ta.my_arena.store(a, std::memory_order_release);
         // increases threading_control's ref count for task_arena
         threading_control::register_public_reference();

--- a/src/tbb/arena.h
+++ b/src/tbb/arena.h
@@ -330,6 +330,14 @@ struct arena_base : padded<intrusive_list_node> {
 
     threading_control_client my_tc_client;
 
+    tbb::task_arena::leave_policy my_leave_policy;
+
+    d1::numa_node_id my_numa_id;
+
+    d1::core_type_id my_core_type;
+
+    int my_max_threads_per_core;
+
 #if TBB_USE_ASSERT
     //! Used to trap accesses to the object after its destruction.
     std::uintptr_t my_guard;
@@ -350,12 +358,12 @@ public:
 
     //! Constructor
     arena(threading_control* control, unsigned max_num_workers, unsigned num_reserved_slots, unsigned priority_level,
-          tbb::task_arena::leave_policy lp
+          d1::constraints constraints, tbb::task_arena::leave_policy lp
     );
 
     //! Allocate an instance of arena.
     static arena& allocate_arena(threading_control* control, unsigned num_slots, unsigned num_reserved_slots,
-                                 unsigned priority_level, tbb::task_arena::leave_policy lp
+                                 unsigned priority_level, d1::constraints constraints, tbb::task_arena::leave_policy lp
     );
 
     static arena& create(threading_control* control, unsigned num_slots, unsigned num_reserved_slots,

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -26,6 +26,7 @@
 #include "common/utils_concurrency_limit.h"
 
 #include "tbb/task_arena.h"
+#include "tbb/info.h"
 #include "tbb/task_scheduler_observer.h"
 #include "tbb/enumerable_thread_specific.h"
 #include "tbb/parallel_for.h"
@@ -36,6 +37,7 @@
 #include "tbb/task_group.h"
 
 #include <atomic>
+#include <algorithm>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
@@ -594,6 +596,9 @@ struct TaskArenaValidator {
     // Inspect the internal state
     int concurrency() { return my_arena.debug_max_concurrency(); }
     int reserved_for_masters() { return my_arena.debug_reserved_slots(); }
+    tbb::task_arena::priority priority() { return my_arena.debug_priority(); }
+    tbb::task_arena::leave_policy leave_policy() { return my_arena.debug_leave_policy(); }
+    tbb::task_arena::constraints constraints() { return my_arena.debug_constraints(); }
 
     // This method should be called in task_arena::execute() for a captured arena
     // by the same thread that created the validator.
@@ -675,11 +680,70 @@ struct TestAttachBody : utils::NoAssign {
 
 thread_local int TestAttachBody::my_idx;
 
+void ValidateArenaSettings( const tbb::task_arena& arena, const tbb::task_arena::constraints& expected_constraints,
+                            int expected_masters, tbb::task_arena::priority expected_priority,
+                            tbb::task_arena::leave_policy expected_leave_policy ) {
+    TaskArenaValidator validator( arena );
+    tbb::task_arena::constraints actual_constraints = validator.constraints();
+    CHECK_MESSAGE( actual_constraints.max_concurrency == expected_constraints.max_concurrency,
+            "Unexpected arena size" );
+    CHECK_MESSAGE( actual_constraints.numa_id == expected_constraints.numa_id,
+            "Unexpected NUMA node id" );
+    CHECK_MESSAGE( actual_constraints.core_type == expected_constraints.core_type,
+            "Unexpected core type id" );
+    CHECK_MESSAGE( actual_constraints.max_threads_per_core == expected_constraints.max_threads_per_core,
+            "Unexpected number of threads per core" );
+
+    CHECK_MESSAGE( validator.reserved_for_masters() == expected_masters,
+            "Unexpected number of reserved slots" );
+    CHECK_MESSAGE( validator.priority() == expected_priority, "Unexpected priority" );
+    CHECK_MESSAGE( validator.leave_policy() == expected_leave_policy, "Unexpected leave policy" );
+}
+
+void TestArenaPreservedSettings() {
+    const int reserved_slots = 2;
+    const auto arena_priority = tbb::task_arena::priority::high;
+    const auto arena_leave_policy = tbb::task_arena::leave_policy::fast;
+
+    tbb::task_arena::constraints arena_constraints{};
+    arena_constraints.set_numa_id( tbb::info::numa_nodes().front() )
+                     .set_core_type( tbb::info::core_types().front() )
+                     .set_max_threads_per_core( 1 );
+    arena_constraints.set_max_concurrency(
+        std::max( reserved_slots, tbb::info::default_concurrency(arena_constraints) ) );
+
+    tbb::task_arena arena( arena_constraints, reserved_slots, arena_priority, arena_leave_policy );
+    ValidateArenaSettings( arena, arena_constraints, reserved_slots, arena_priority, arena_leave_policy );
+
+    tbb::task_arena copied_arena( arena );
+    ValidateArenaSettings( copied_arena, arena_constraints, reserved_slots, arena_priority, arena_leave_policy );
+
+    arena.execute( [&] {
+        tbb::task_arena attached_arena{ tbb::task_arena::attach{} };
+        CHECK_MESSAGE( attached_arena.is_active(), "The arena was not attached" );
+        ValidateArenaSettings( attached_arena, arena_constraints, reserved_slots, arena_priority,
+                               arena_leave_policy );
+
+        // Copying an attached arena copies the settings but not the reference
+        tbb::task_arena copied_from_attached_arena( attached_arena );
+        CHECK_MESSAGE( !copied_from_attached_arena.is_active(), "A copy of an arena should not be initialized" );
+        ValidateArenaSettings( copied_from_attached_arena, arena_constraints, reserved_slots, arena_priority,
+                               arena_leave_policy );
+
+        copied_from_attached_arena.initialize();
+        ValidateArenaSettings( copied_from_attached_arena, arena_constraints, reserved_slots, arena_priority,
+                               arena_leave_policy );
+    } );
+}
+
 void TestAttach( int maxthread ) {
     // Externally concurrent, but no concurrency within a thread
     utils::NativeParallelFor( std::max(maxthread,4), TestAttachBody( maxthread ) );
     // Concurrent within the current arena; may also serve as a stress test
     tbb::parallel_for( Range(0,10000*maxthread), TestAttachBody( maxthread ) );
+    // Checks that all the settings of an explicitly created arena survive both
+    // the attach to it and the copying
+    TestArenaPreservedSettings();
 }
 
 //--------------------------------------------------//


### PR DESCRIPTION
### Description
Currently, only some of the task_arena settings are saved during "attach" construction (max_concurrency, reserved_slots, priority), but not constraints and not leave policy. This leads to such scenario:
```cpp
task_arena outer_ta{constraints.set_core_type(some_id)};
outer_ta.execute([&outer_ta] {
    task_arena inner_ta(attach); // will be constrained, but settings are not actually saved into "task_arena"
    task_arena inner_copy(inner_ta) // it won't be constrained!
});
```
This patch stores that information in `r1::arena` and sets it during attach construction of `task_arena`

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [x] updated
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
