### PR TITLE
Fix FIFO task deadlock during nested waits

### DIFF
--- a/src/tbb/task_dispatcher.h
+++ b/src/tbb/task_dispatcher.h
@@ -299,7 +299,7 @@ d1::task* task_dispatcher::local_wait_for_all(d1::task* t, Waiter& waiter ) {
     ed.wait_ctx = waiter.wait_ctx();
 
     m_properties.outermost = false;
-    m_properties.fifo_tasks_allowed = false;
+    m_properties.fifo_tasks_allowed = dl_guard.old_properties.fifo_tasks_allowed;
 
     if (!dl_guard.is_initially_registered) {
         m_thread_data->my_arena->my_tc_client.get_pm_client()->register_thread();

--- a/test/tbb/test_task_arena.cpp
+++ b/test/tbb/test_task_arena.cpp
@@ -2253,6 +2253,27 @@ TEST_CASE("Test enqueue guarantees when task_arena is combined with task_group")
 
 #endif // TBB_USE_EXCEPTIONS
 
+//! \brief \ref regression
+TEST_CASE("FIFO task enqueued during local_wait_for_all is consumed in single-slot arena") {
+    tbb::task_arena ta{1, 0};
+    tbb::task_group outer;
+    std::atomic<bool> inner_ran{false};
+
+    ta.enqueue([&] {
+        tbb::task_group inner;
+
+        ta.enqueue([&] {
+            inner_ran.store(true, std::memory_order_release);
+        }, inner);
+
+        inner.wait();
+    }, outer);
+
+    ta.wait_for(outer);
+
+    REQUIRE(inner_ran.load(std::memory_order_acquire));
+}
+
 #if __TBB_CPP17_PRESENT
 //! \brief \ref regression
 TEST_CASE("ODR-use task_arena constants") {


### PR DESCRIPTION
### Description

When a single-slot `task_arena` executes a FIFO task that enqueues another FIFO task and waits for it, `local_wait_for_all` could disable FIFO consumption for nested waits. This caused the only worker to wait indefinitely.

This change preserves the inherited `fifo_tasks_allowed` state when entering `local_wait_for_all`, allowing nested waits to consume FIFO tasks when FIFO execution was already permitted.

Fixes #2156

### Type of change

- [x] bug fix
- [ ] new feature
- [x] tests
- [ ] infrastructure
- [ ] documentation

### Tests

- [x] added
- [ ] not needed

### Documentation

- [ ] updated
- [x] not needed

### Breaks backward compatibility

- [ ] Yes
- [x] No

### Other information

The regression test timed out on the original code and passes after the fix.

Related tests passed:
- `test_task_arena`
- `test_task_group`
- `conformance_task_arena`
