### PR TITLE
Simplify constrained nested arena test

### DIFF
--- a/test/common/common_arena_constraints.h
+++ b/test/common/common_arena_constraints.h
@@ -313,7 +313,7 @@ private:
             hwloc_bitmap_or(buffer_cpu_set, buffer_cpu_set, numa_node_info.cpuset);
         }
         REQUIRE_MESSAGE( hwloc_bitmap_isequal(buffer_cpu_set, process_cpuset),
-            "Intersected NUMA nodes masks should be equal to process affinity.(reference)");
+            "The union of NUMA nodes masks should be equal to process affinity.(reference)");
 
         // Core types topology verification
         hwloc_bitmap_zero(buffer_cpu_set);
@@ -324,7 +324,7 @@ private:
             hwloc_bitmap_or(buffer_cpu_set, buffer_cpu_set, cpu_kind_info.cpuset);
         }
         REQUIRE_MESSAGE(hwloc_bitmap_isequal(buffer_cpu_set, process_cpuset),
-            "Intersected core type masks should be equal to process affinity.(reference)");
+            "The union of core type masks should be equal to process affinity.(reference)");
 
         hwloc_bitmap_free(buffer_cpu_set);
     }

--- a/test/tbb/test_arena_constraints.cpp
+++ b/test/tbb/test_arena_constraints.cpp
@@ -146,33 +146,28 @@ TEST_CASE("Test constrained nested arena of smaller size") {
     }
 
     using namespace tbb::info;
-    system_info::initialize();
 
     tbb::task_arena::constraints c{numa_nodes().back()};
     c.set_core_type(core_types().back());
     c.set_max_threads_per_core(1);
     c.set_max_concurrency(1); // Make the constrained arena smaller than the outer arena, which has n > 1 threads.
 
-    system_info::affinity_mask outer_affinity = system_info::allocate_current_affinity_mask();
+    std::atomic<bool> current_thread_index_exceeded_0{false};
     utils::SpinBarrier barrier(n);
 
     // parallel_for body runs in the implicit arena, which spans all available threads.
     tbb::parallel_for(0, n, [&](int) {
+        if (tbb::this_task_arena::current_thread_index() > 0) {
+            current_thread_index_exceeded_0 = true;
+        }
         // TBBBind changes thread affinity when entering the smaller constrained arena and restores it on exit.
         // current_thread_index() exceeding the smaller arena size no longer causes out of range access in TBBBind.
-        tbb::task_arena{c}.execute([&] {
-            system_info::affinity_mask inner_affinity = system_info::allocate_current_affinity_mask();
-            REQUIRE_MESSAGE(hwloc_bitmap_isincluded(inner_affinity, outer_affinity),
-                "Nested constrained arena affinity mask is not a subset of the outer affinity mask.");
-
-            // Indirectly verify that TBBBind applied the affinity for this arena.
-            if (tbb::detail::r1::constraints_default_concurrency(c) < n) { // affinity mask should be smaller
-                REQUIRE_MESSAGE(!hwloc_bitmap_isequal(inner_affinity, outer_affinity),
-                    "TBBBind did not apply affinity: the nested arena mask was not narrowed.");
-            }
+        tbb::task_arena{c}.execute([] {
+            REQUIRE_MESSAGE(tbb::this_task_arena::max_concurrency() == 1, "Nested arena should have 1 slot.");
         });
         barrier.wait();
     }, tbb::simple_partitioner{});
+    REQUIRE(current_thread_index_exceeded_0);
 }
 #endif /*__TBB_HWLOC_VALID_ENVIRONMENT && __HWLOC_CPUBIND_PRESENT */
 


### PR DESCRIPTION
### Description 
The constrained nested arena test could fail on Windows systems with a NUMA node spanning across multiple processor groups due to its incorrect helper API usage: `allocate_current_affinity_mask()` was influenced by the current processor group (`get_arena_affinity()` could have been used instead). This patch makes the test independent of actual binding behavior and instead focuses on the regression that was fixed (#2121) by removing direct affinity mask comparisons and instead verifying that the nested arena has only 1 slot, and that `current_thread_index()` can exceed 0.

Also, updated the assertion messages in `common_arena_constraints.h` to clarify that the tests are checking for the union of NUMA node and core type masks being equal to process affinity, rather than intersection.

### Type of change
- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests
- [x] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation
- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown