### PR TITLE
Move custom assertion handler to TBB namespace

### DIFF
--- a/doc/main/reference/examples/assertion_handler.cpp
+++ b/doc/main/reference/examples/assertion_handler.cpp
@@ -19,9 +19,7 @@
 #include <oneapi/tbb/global_control.h>
 #include <fstream>
 
-#ifdef TBB_EXT_CUSTOM_ASSERTION_HANDLER
-
-auto default_handler = tbb::ext::get_assertion_handler();
+auto default_handler = tbb::get_assertion_handler();
 
 void wrapper_assertion_handler(const char* location, int line,
                                const char* expression, const char* comment) {
@@ -34,20 +32,14 @@ void wrapper_assertion_handler(const char* location, int line,
     default_handler(location, line, expression, comment);
 }
 
-#endif // TBB_EXT_CUSTOM_ASSERTION_HANDLER
-
 int main() {
-#ifdef TBB_EXT_CUSTOM_ASSERTION_HANDLER
     // Set custom handler
-    tbb::ext::set_assertion_handler(wrapper_assertion_handler);
-#endif // TBB_EXT_CUSTOM_ASSERTION_HANDLER
+    tbb::set_assertion_handler(wrapper_assertion_handler);
 
     // Use oneTBB normally - any assertion failures will use custom handler
     // ...
 
-#ifdef TBB_EXT_CUSTOM_ASSERTION_HANDLER
     // Restore the default handler
-    tbb::ext::set_assertion_handler(nullptr);
-#endif // TBB_EXT_CUSTOM_ASSERTION_HANDLER
+    tbb::set_assertion_handler(nullptr);
 }
 /*end_assertion_handler_example*/

--- a/include/oneapi/tbb.cppm
+++ b/include/oneapi/tbb.cppm
@@ -129,13 +129,14 @@ export namespace tbb {
     using tbb::v1::attach;
     using tbb::v1::finalize;
     using tbb::v1::task_scheduler_handle;
-#if !__TBB_DISABLE_SPEC_EXTENSIONS
+    using tbb::v1::assertion_handler_type;
+    using tbb::v1::set_assertion_handler;
+    using tbb::v1::get_assertion_handler;
     namespace ext {
         using tbb::ext::v1::assertion_handler_type;
         using tbb::ext::v1::set_assertion_handler;
         using tbb::ext::v1::get_assertion_handler;
     } // namespace ext
-#endif
 
     namespace task {
 #if __TBB_RESUMABLE_TASKS

--- a/include/oneapi/tbb.cppm
+++ b/include/oneapi/tbb.cppm
@@ -132,11 +132,6 @@ export namespace tbb {
     using tbb::v1::assertion_handler_type;
     using tbb::v1::set_assertion_handler;
     using tbb::v1::get_assertion_handler;
-    namespace ext {
-        using tbb::ext::v1::assertion_handler_type;
-        using tbb::ext::v1::set_assertion_handler;
-        using tbb::ext::v1::get_assertion_handler;
-    } // namespace ext
 
     namespace task {
 #if __TBB_RESUMABLE_TASKS

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -560,9 +560,10 @@
 #define __TBB_PREVIEW_NUMA_ALLOCATION 1
 #endif
 
-#if !__TBB_DISABLE_SPEC_EXTENSIONS
+// EXT macro is kept for compatibility with code built against
+// older oneTBB releases, where the custom assertion handler was
+// available only via the extension API
 #define TBB_EXT_CUSTOM_ASSERTION_HANDLER 202510
-#endif
 
 // Feature-test macros
 #if __TBB_PREVIEW_FLOW_GRAPH_RESOURCE_LIMITING
@@ -586,5 +587,7 @@
 #if __TBB_PREVIEW_NUMA_ALLOCATION
 #define TBB_HAS_NUMA_ALLOCATION 202605
 #endif
+
+#define TBB_HAS_CUSTOM_ASSERTION_HANDLER 202608
 
 #endif // __TBB_detail__config_H

--- a/include/oneapi/tbb/global_control.h
+++ b/include/oneapi/tbb/global_control.h
@@ -208,15 +208,20 @@ using detail::d1::attach;
 using detail::d1::finalize;
 using detail::d1::task_scheduler_handle;
 using detail::r1::unsafe_wait;
+
+using detail::r1::assertion_handler_type;
+using detail::r1::set_assertion_handler;
+using detail::r1::get_assertion_handler;
 } // namespace v1
 
+// Definitions in namespace ext are kept for compatibility
+// with code built against older oneTBB releases, where
+// the custom assertion handler was available only via the extension API
 namespace ext {
 inline namespace v1 {
-#if !__TBB_DISABLE_SPEC_EXTENSIONS
 using ::tbb::detail::r1::assertion_handler_type;
 using ::tbb::detail::r1::set_assertion_handler;
 using ::tbb::detail::r1::get_assertion_handler;
-#endif
 } // inline namespace v1
 } // namespace ext
 

--- a/rfcs/supported/assertion_handler/README.md
+++ b/rfcs/supported/assertion_handler/README.md
@@ -56,8 +56,6 @@ compatibility:
 ```cpp
 namespace oneapi {
 namespace tbb {
-namespace ext {
-#if !__TBB_DISABLE_SPEC_EXTENSIONS
     //! Type alias for assertion handler function pointer - same as TBB 2020.
     //! The handler should not return. If it eventually returns, the behavior is runtime-undefined.
     using assertion_handler_type = void(*)(const char* location, int line,
@@ -71,31 +69,17 @@ namespace ext {
     //! Return the current assertion handler.
     //! New function not present in TBB 2020, following std::get_terminate pattern.
     assertion_handler_type get_assertion_handler() noexcept;
-#endif
-}}}
+}}
 ```
 
 Applications that used the custom assertion handler in TBB 2020 can migrate to this proposal with minimal changes
 by adding names to `namespace tbb`:
 ```cpp
 namespace tbb {
-    using oneapi::tbb::ext::set_assertion_handler;
-    using oneapi::tbb::ext::assertion_handler_type;
+    using oneapi::tbb::set_assertion_handler;
+    using oneapi::tbb::assertion_handler_type;
 }
 ```
-
-#### Specification Extension
-
-This API is introduced as an extension to the oneTBB specification, controlled by the
-`__TBB_DISABLE_SPEC_EXTENSIONS` macro. By default (macro undefined or defined as 0), the extension will
-be enabled: `set_assertion_handler` and `get_assertion_handler` will be declared and exported, and
-`assertion_failure` will dispatch to the active handler. Defining `__TBB_DISABLE_SPEC_EXTENSIONS` to a non-zero
-value before including oneTBB headers will disable the extension: these declarations will be excluded from
-the public API, and the library will always use the default assertion behavior.
-
-The availability of the extension can be checked with the `TBB_EXT_CUSTOM_ASSERTION_HANDLER` macro
-after including either the `oneapi/tbb/global_control.h` or the `oneapi/tbb/version.h` header.
-The value of the macro should be increased when observable modifications are made to the feature.
 
 ### Proposed Implementation Strategy
 

--- a/rfcs/supported/assertion_handler/README.md
+++ b/rfcs/supported/assertion_handler/README.md
@@ -72,14 +72,7 @@ namespace tbb {
 }}
 ```
 
-Applications that used the custom assertion handler in TBB 2020 can migrate to this proposal with minimal changes
-by adding names to `namespace tbb`:
-```cpp
-namespace tbb {
-    using oneapi::tbb::set_assertion_handler;
-    using oneapi::tbb::assertion_handler_type;
-}
-```
+Applications that used the custom assertion handler in TBB 2020 can migrate to this proposal with no changes.
 
 ### Proposed Implementation Strategy
 

--- a/test/common/utils_assert.h
+++ b/test/common/utils_assert.h
@@ -134,9 +134,9 @@ void AssertionFailureHandler(const char* filename, int line,
 }
 #endif
 
-tbb::ext::assertion_handler_type SetCustomAssertionHandler() {
-    auto default_handler = tbb::ext::set_assertion_handler(AssertionFailureHandler);
-    auto custom_handler = tbb::ext::get_assertion_handler();
+tbb::assertion_handler_type SetCustomAssertionHandler() {
+    auto default_handler = tbb::set_assertion_handler(AssertionFailureHandler);
+    auto custom_handler = tbb::get_assertion_handler();
     REQUIRE_MESSAGE(custom_handler == AssertionFailureHandler,
                     "Custom assertion handler was not set.");
     return default_handler;
@@ -152,11 +152,11 @@ void CheckAssertionFailure(int line, std::string expression, bool okay,
         expression, " failed with message '", msg_str, "' missing substring '", substr, "'");
 }
 
-void ResetAssertionHandler(tbb::ext::assertion_handler_type default_handler) {
-    auto handler = tbb::ext::set_assertion_handler(nullptr); // Reset to default handler
+void ResetAssertionHandler(tbb::assertion_handler_type default_handler) {
+    auto handler = tbb::set_assertion_handler(nullptr); // Reset to default handler
     REQUIRE_MESSAGE(handler == AssertionFailureHandler,
                     "Previous assertion handler was not returned.");
-    REQUIRE_MESSAGE(tbb::ext::get_assertion_handler() == default_handler,
+    REQUIRE_MESSAGE(tbb::get_assertion_handler() == default_handler,
                     "Default assertion handler was not reset.");
 }
 

--- a/test/tbb/test_global_control.cpp
+++ b/test/tbb/test_global_control.cpp
@@ -287,7 +287,7 @@ TEST_CASE("test concurrent task_scheduler_handle destruction") {
 TEST_CASE("Assertion handler type") {
     using documented = void(*)(const char* /* location */, int /* line */,
                                const char* /* expression */, const char* /* comment */);
-    static_assert(std::is_same<oneapi::tbb::ext::assertion_handler_type, documented>::value,
+    static_assert(std::is_same<oneapi::tbb::assertion_handler_type, documented>::value,
                   "Incorrect assertion handler type");
 }
 
@@ -299,11 +299,6 @@ TEST_CASE("Using custom assertion handler to test failure on invalid max_allowed
         "max_allowed_parallelism cannot be 0.");
 }
 
-namespace tbb {
-    using oneapi::tbb::ext::set_assertion_handler;
-    using oneapi::tbb::ext::assertion_handler_type;
-}
-
 //! Check that namespace injection allows to provide TBB 2020 source compatibility
 //! \brief \ref interface
 TEST_CASE("Check that namespace injection allows to provide TBB 2020 source compatibility") {
@@ -311,4 +306,17 @@ TEST_CASE("Check that namespace injection allows to provide TBB 2020 source comp
 
     tbb::assertion_handler_type old_handler = tbb::set_assertion_handler(new_handler);
     REQUIRE(old_handler != new_handler);
+}
+
+//! \brief \ref interface
+TEST_CASE("Assertion handler feature-test macro") {
+    CHECK_MESSAGE(TBB_HAS_CUSTOM_ASSERTION_HANDLER == 202608, "Incorrect assertion handler feature-test macro");
+}
+
+//! \brief \ref interface
+TEST_CASE("Assertion handler compatibility API") {
+    CHECK_MESSAGE((std::is_same<tbb::assertion_handler_type, tbb::ext::assertion_handler_type>::value),
+                  "Incorrect compat assertion_handler_type");
+    CHECK_MESSAGE(&tbb::get_assertion_handler == &tbb::ext::get_assertion_handler, "Incorrect compat get_assertion_handler");
+    CHECK_MESSAGE(&tbb::set_assertion_handler == &tbb::ext::set_assertion_handler, "Incorrect compat set_assertion_handler");
 }

--- a/test/tbb/test_tbb_header.cpp
+++ b/test/tbb/test_tbb_header.cpp
@@ -228,7 +228,7 @@ export inline void DefinitionPresence() {
 #else
 static void DefinitionPresence() {
 #endif
-    TestTypeDefinitionPresence( ext::assertion_handler_type );
+    TestTypeDefinitionPresence( assertion_handler_type );
     TestTypeDefinitionPresence( cache_aligned_allocator<int> );
     TestTypeDefinitionPresence( tbb_hash_compare<int> );
     TestTypeDefinitionPresence2( concurrent_hash_map<int, int> );
@@ -250,11 +250,11 @@ static void DefinitionPresence() {
     TestTypeDefinitionPresence( flattened2d<tbb::enumerable_thread_specific<std::vector<int>>> );
     TestTypeDefinitionPresence( ets_key_usage_type );
     TestFuncDefinitionPresence( flatten2d, (const tbb::enumerable_thread_specific<std::vector<int>>&), tbb::flattened2d<tbb::enumerable_thread_specific<std::vector<int>>> );
-    TestFuncDefinitionPresence( ext::get_assertion_handler, (),
-                                tbb::ext::assertion_handler_type );
-    TestFuncDefinitionPresence( ext::set_assertion_handler,
-                                (tbb::ext::assertion_handler_type),
-                                tbb::ext::assertion_handler_type );
+    TestFuncDefinitionPresence( get_assertion_handler, (),
+                                tbb::assertion_handler_type );
+    TestFuncDefinitionPresence( set_assertion_handler,
+                                (tbb::assertion_handler_type),
+                                tbb::assertion_handler_type );
     /* Flow graph names */
     TestTypeDefinitionPresence( flow::graph );
     TestTypeDefinitionPresence( flow::continue_msg );


### PR DESCRIPTION
### Description 
Since the TBB specification is merging with the reference, having the specification extensions is meaningless.
This PR moves the `tbb::ext::get/set_assertion_handler and tbb::ext::assertion_handler_type` to the TBB namespace.

For compatibility reasons, definitions in `ext` namespace are preserved.
The corresponding documentation update is done as part of #2159 


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
