### PR TITLE
Reduce number of iterations for TestCleanupMaster under sanitizers

### DIFF
--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -1,5 +1,6 @@
 /*
     Copyright (c) 2005-2024 Intel Corporation
+    Copyright (c) 2026 UXL Foundation Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/tbb/test_resumable_tasks.cpp
+++ b/test/tbb/test_resumable_tasks.cpp
@@ -309,7 +309,13 @@ void TestCleanupMaster() {
     std::atomic<int> iter_spawned;
     std::atomic<int> iter_executed;
 
-    for (int i = 0; i < 100; i++) {
+#if __TBB_USE_SANITIZERS
+    constexpr int max_iters = 25;
+#else
+    constexpr int max_iters = 100;
+#endif
+
+    for (int i = 0; i < max_iters; i++) {
         iter_spawned = 0;
         iter_executed = 0;
 


### PR DESCRIPTION
### Description 
Test takes too long under sanitizers and may even exceed 600 seconds timeout if run on significant amount of threads

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [x] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
