### PR TITLE
expand specification of resumable tasks

### DIFF
--- a/doc/main/specification/source/task_scheduler/scheduling_controls/resumable_tasks.rst
+++ b/doc/main/specification/source/task_scheduler/scheduling_controls/resumable_tasks.rst
@@ -27,10 +27,8 @@ The user-specified callable object is executed by the calling thread. An excepti
 caller of the ``oneapi::tbb::task::suspend`` function.
 
 The ``oneapi::tbb::task::suspend_point`` context tag must be passed to the ``oneapi::tbb::task::resume`` function to trigger a program execution at the suspended point.
-The ``oneapi::tbb::task::resume`` function can be called at any point of an application, even on a separate thread.
+The ``oneapi::tbb::task::resume`` function can be called at any point of an application, including on a separate thread or directly from the user callable object passed to the ``oneapi::tbb::task::suspend`` function.
 In this regard, this function acts as a signal for the task scheduler.
-The ``oneapi::tbb::task::resume`` function can be called from within the user callable object passed to the ``oneapi::tbb::task::suspend`` function to cancel
-the suspension of the task execution.
 
 .. note::
 

--- a/doc/main/specification/source/task_scheduler/scheduling_controls/resumable_tasks.rst
+++ b/doc/main/specification/source/task_scheduler/scheduling_controls/resumable_tasks.rst
@@ -23,17 +23,21 @@ Requirements:
 
 The ``oneapi::tbb::task::suspend`` function called within a running task suspends execution of the task and switches the thread to participate in other oneTBB parallel work.
 This function accepts a user callable object with the current execution context ``oneapi::tbb::task::suspend_point`` as an argument.
-The user-specified callable object is executed by the calling thread.
+The user-specified callable object is executed by the calling thread. An exception thrown from the callable object prevents the task from suspending and is propagated to the
+caller of the ``oneapi::tbb::task::suspend`` function.
 
 The ``oneapi::tbb::task::suspend_point`` context tag must be passed to the ``oneapi::tbb::task::resume`` function to trigger a program execution at the suspended point.
 The ``oneapi::tbb::task::resume`` function can be called at any point of an application, even on a separate thread.
 In this regard, this function acts as a signal for the task scheduler.
+The ``oneapi::tbb::task::resume`` function can be called from within the user callable object passed to the ``oneapi::tbb::task::suspend`` function to cancel
+the suspension of the task execution.
 
 .. note::
 
     There are no guarantees that the same thread that called ``oneapi::tbb::task::suspend`` continues execution after the suspended point.
     However, these guarantees are provided for the outermost blocking oneTBB calls
     (such as ``oneapi::tbb::parallel_for`` and ``oneapi::tbb::flow::graph::wait_for_all``) and ``oneapi::tbb::task_arena::execute`` calls.
+    :doc:`A thread local storage <../../thread_local_storage/enumerable_thread_specific_cls>` can be configured with the ``ets_suspend_aware`` key type to be preserved across task suspension and resumption.
 
 Example
 -------


### PR DESCRIPTION
### Description 

I propose to expand the specification of resumable tasks to address two concerns:
- What happens if the user provided callable throws?
- How to cancel suspension, for example registering a callback to some async runtime failed?

AFAIK what I propose describes the current but not documented behaviour

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [ ] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [x] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [x] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [x] not needed

### Breaks backward compatibility
- [ ] Yes
- [x] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
