### PR TITLE
Set core_type and max_threads_per_core only for supported arenas

### DIFF
--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -638,6 +638,8 @@ bool task_arena_impl::attach(d1::task_arena_base& ta) {
         ta.my_max_concurrency = ta.my_num_reserved_slots + a->my_max_num_workers;
         __TBB_ASSERT(arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots) == a->my_num_slots, nullptr);
         ta.my_numa_id = a->my_numa_id;
+        // Older task_arena_base layouts do not include my_core_type and my_max_threads_per_core
+        // Check the trait before accessing them to preserve backward compatibility
         if (ta.my_version_and_traits & d1::task_arena_base::core_type_support_flag) {
             ta.my_core_type = a->my_core_type;
             ta.my_max_threads_per_core = a->my_max_threads_per_core;

--- a/src/tbb/arena.cpp
+++ b/src/tbb/arena.cpp
@@ -638,8 +638,10 @@ bool task_arena_impl::attach(d1::task_arena_base& ta) {
         ta.my_max_concurrency = ta.my_num_reserved_slots + a->my_max_num_workers;
         __TBB_ASSERT(arena::num_arena_slots(ta.my_max_concurrency, ta.my_num_reserved_slots) == a->my_num_slots, nullptr);
         ta.my_numa_id = a->my_numa_id;
-        ta.my_core_type = a->my_core_type;
-        ta.my_max_threads_per_core = a->my_max_threads_per_core;
+        if (ta.my_version_and_traits & d1::task_arena_base::core_type_support_flag) {
+            ta.my_core_type = a->my_core_type;
+            ta.my_max_threads_per_core = a->my_max_threads_per_core;
+        }
         ta.set_leave_policy(a->my_leave_policy);
         ta.my_arena.store(a, std::memory_order_release);
         // increases threading_control's ref count for task_arena


### PR DESCRIPTION
### Description 
2021.1 version of `task_arena` does not have `my_core_type` and `my_max_threads_per_core` fields and unconditional set may break compatibility.


Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
