### PR TITLE
[TCM] Use correct path for .lib files in vars.bat

### DIFF
--- a/thread_composability_manager/integration/windows/vars/vars.bat.in
+++ b/thread_composability_manager/integration/windows/vars/vars.bat.in
@@ -42,7 +42,7 @@ if exist "%TCM_BIN_DIR%" (
     set "INCLUDE=%TCMROOT%\include;%INCLUDE%"
     set "C_INCLUDE_PATH=%TCMROOT%\include;%C_INCLUDE_PATH%"
     set "CPLUS_INCLUDE_PATH=%TCMROOT%\include;%CPLUS_INCLUDE_PATH%"
-    set "LIB=@LIBRARY_PATH_PLACEHOLDER@;%LIB%"
+    set "LIB=%TCM_LIB_DIR%;%LIB%"
     set "PATH=%TCM_BIN_DIR%;%PATH%"
 ) else (
     echo:

--- a/thread_composability_manager/integration/windows/vars/vars.bat.in
+++ b/thread_composability_manager/integration/windows/vars/vars.bat.in
@@ -29,11 +29,14 @@ if /i "%1"=="intel64"      (set TCM_TARGET_ARCH=intel64)  & shift & goto ParseAr
 :SetEnv
 if "%TCM_TARGET_ARCH%" == "ia32" (
     set "TCM_DEFAULT_BIN_NAME=bin32"
+    set "TCM_DEFAULT_LIB_NAME=lib32"
 ) else (
     set "TCM_DEFAULT_BIN_NAME=bin"
+    set "TCM_DEFAULT_LIB_NAME=lib"
 )
 
 set "TCM_BIN_DIR=@BINARY_PATH_PLACEHOLDER@"
+set "TCM_LIB_DIR=@LIBRARY_PATH_PLACEHOLDER@"
 
 if exist "%TCM_BIN_DIR%" (
     set "INCLUDE=%TCMROOT%\include;%INCLUDE%"


### PR DESCRIPTION
### Description 
This PR fixes the issue with path to .lib files on Windows in vars.bat 

Fixes # - _issue number(s) if exists_

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [X] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [X] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [X] not needed

### Breaks backward compatibility
- [ ] Yes
- [X] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
