### PR TITLE
Fix polymorphic memory resource feature detection on libc++ + add conditional export in the module

### DIFF
--- a/include/oneapi/tbb.cppm
+++ b/include/oneapi/tbb.cppm
@@ -98,10 +98,15 @@ export namespace tbb {
 
     // Memory Allocation
     using tbb::v1::cache_aligned_allocator;
-    using tbb::v1::cache_aligned_resource;
     using tbb::v1::scalable_allocator;
-    using tbb::v1::scalable_memory_resource;
     using tbb::v1::tbb_allocator;
+
+    // libc++ added partial module support before implementing polymorphic memory
+    // resources, so the presence of this C++17 feature must be checked explicitly.
+#if __TBB_CPP17_MEMORY_RESOURCE_PRESENT
+    using tbb::v1::cache_aligned_resource;
+    using tbb::v1::scalable_memory_resource;
+#endif
 #if __TBB_PREVIEW_MEMORY_POOL
     using tbb::v1::memory_pool_allocator;
     using tbb::v1::memory_pool;

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -263,8 +263,8 @@
 // GCC4.8 on RHEL7 does not support std::is_trivially_copyable
 #define __TBB_CPP11_TYPE_PROPERTIES_PRESENT             (_LIBCPP_VERSION || _MSC_VER >= 1700 || (__TBB_GLIBCXX_VERSION >= 50000 && __GXX_EXPERIMENTAL_CXX0X__))
 
-#define __TBB_CPP17_MEMORY_RESOURCE_PRESENT             (_MSC_VER >= 1913 && (__TBB_LANG > 201402L) || \
-                                                        __TBB_GLIBCXX_VERSION >= 90000 && __TBB_LANG >= 201703L)
+#define __TBB_CPP17_MEMORY_RESOURCE_PRESENT             ((_MSC_VER >= 1913 && __TBB_LANG > 201402L) || \
+                                                         (__TBB_LANG >= 201703L && (__TBB_GLIBCXX_VERSION >= 90000 || _LIBCPP_VERSION >= 160000)))
 #define __TBB_CPP17_HW_INTERFERENCE_SIZE_PRESENT        (_MSC_VER >= 1911)
 #define __TBB_CPP17_LOGICAL_OPERATIONS_PRESENT          (__TBB_LANG >= 201703L)
 #define __TBB_CPP17_ALLOCATOR_IS_ALWAYS_EQUAL_PRESENT   (__TBB_LANG >= 201703L)

--- a/include/oneapi/tbb/detail/_config.h
+++ b/include/oneapi/tbb/detail/_config.h
@@ -490,7 +490,7 @@
 **/
 
 // Some STL containers not support allocator traits in old GCC versions
-#if __GXX_EXPERIMENTAL_CXX0X__ && __TBB_GLIBCXX_VERSION <= 50301
+#if __GXX_EXPERIMENTAL_CXX0X__ && __TBB_GLIBCXX_VERSION && __TBB_GLIBCXX_VERSION <= 50301
     #define TBB_ALLOCATOR_TRAITS_BROKEN 1
 #endif
 


### PR DESCRIPTION
### Description 
`std::pmr::memory_resource` was added into libc++ 16.0.0.
TBB configs incorrectly detect this feature as unimplemented, even on the supported platforms.

This fix also introduces guards into tbb.cppm. Detecting the presence of C++17 feature in the module is required
since libc++ have implemented partial support for modules before introducing polymorphic memory resources.


Fixes #2187 

### Type of change

_Choose one or multiple, leave empty if none of the other choices apply_

_Add a respective label(s) to PR if you have permissions_

- [x] bug fix - _change that fixes an issue_
- [ ] new feature - _change that adds functionality_
- [ ] tests - _change in tests_
- [ ] infrastructure - _change in infrastructure and CI_
- [ ] documentation - _documentation update_

### Tests

- [ ] added - _required for new features and some bug fixes_
- [ ] not needed

### Documentation

- [ ] updated in # - _add PR number_
- [ ] needs to be updated
- [ ] not needed

### Breaks backward compatibility
- [ ] Yes
- [ ] No
- [ ] Unknown

### Notify the following users
_List users with `@` to send notifications_

### Other information
